### PR TITLE
Seperate out PR builds from full branch builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - develop
-  pull_request:
-    branches:
-      - master
-      - develop
 
 jobs:
   build:

--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -1,0 +1,25 @@
+name: PR build and test
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  pr-build:
+    # run on macOS so it can do ui stuff
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.11.0
+      - name: Build and test
+        run: |
+          npm install
+          npm run compile
+          npm run lint
+          npm test


### PR DESCRIPTION
This is so:
1. We can have a badge for the full branch builds in the README that won't
   collide with the pr builds
2. We can have the full branch builds do more things (e.g. build the .vsix's,
   matrix across os'es)
