### PR TITLE
Allows literal nulls in fields where runtime supports it

### DIFF
--- a/extensions/analyticsdx-vscode-templates/schemas/template-info-schema.json
+++ b/extensions/analyticsdx-vscode-templates/schemas/template-info-schema.json
@@ -55,6 +55,9 @@
           "type": "string",
           "$comment": "These are also valid in the server, but we shouldn't prompt users for them. Also, json-schema doesn't support sending in a case-sensitive flag nor doing a (?i) group.",
           "pattern": "^(lens|Lens|TemporaryApp|temporaryApp|temporaryapp)$"
+        },
+        {
+          "type": "null"
         }
       ]
     },
@@ -67,23 +70,27 @@
       "description": "The template name that is visible to users."
     },
     "description": {
-      "type": "string",
-      "description": "The template description to tell users about the asset they will be creating using the template."
+      "type": ["null", "string"],
+      "description": "The template description to tell users about the asset they will be creating using the template.",
+      "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
     },
     "assetIcon": {
-      "type": "string",
+      "type": ["null", "string"],
       "deprecationMessage": "Deprecated - use 'icons.appBadge' instead.",
-      "description": "(Deprecated - use 'icons.appBadge' instead) Sets the app icon at creation. There are 20 app icons stored as .png files in Analytics, which are numbered 1-20. If not specified, system will use default icon 1.png for the app."
+      "description": "(Deprecated - use 'icons.appBadge' instead) Sets the app icon at creation. There are 20 app icons stored as .png files in Analytics, which are numbered 1-20. If not specified, system will use default icon 1.png for the app.",
+      "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
     },
     "templateIcon": {
-      "type": "string",
+      "type": ["null", "string"],
       "default": "default.png",
       "deprecationMessage": "Deprecated - use 'icons.templateBadge' instead.",
-      "description": "(Deprecated - use icons.templateBadge instead) Sets the template icon to display in the UI. If not specified, system will use default icon for the template (default.png). Currently, default.png is the only icon ISVs can use."
+      "description": "(Deprecated - use icons.templateBadge instead) Sets the template icon to display in the UI. If not specified, system will use default icon for the template (default.png). Currently, default.png is the only icon ISVs can use.",
+      "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
     },
     "icons": {
-      "type": "object",
+      "type": ["null", "object"],
       "description": "Specifies icons to display in the UI for the template.",
+      "examples": [{}],
       "additionalProperties": false,
       "properties": {
         "appBadge": {
@@ -99,8 +106,9 @@
           "deprecationMessage": "Deprecated - no longer used."
         },
         "templatePreviews": {
-          "type": "array",
+          "type": ["null", "array"],
           "minItems": 0,
+          "examples": [[]],
           "description": "Preview icons for the template.",
           "items": {
             "$ref": "#/definitions/previewIcon",
@@ -127,8 +135,9 @@
           "pattern": "^[0-9]+\\.[0-9]+$"
         },
         "notesFile": {
-          "type": "string",
-          "description": "A template dev defined HTML file to describe new release details. Basic HTML formatting is supported, but not links or javascript. Defaults to using the template description as release notes if file is not specified."
+          "type": ["null", "string"],
+          "description": "A template dev defined HTML file to describe new release details. Basic HTML formatting is supported, but not links or javascript. Defaults to using the template description as release notes if file is not specified.",
+          "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
         }
       },
       "defaultSnippets": [
@@ -142,9 +151,10 @@
       ]
     },
     "rules": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "Defines the rules files for converting to and from the template, loaded 1st to last and order matters for dependencies.",
-      "minItems": 1,
+      "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -192,21 +202,25 @@
       ]
     },
     "ruleDefinition": {
-      "type": "string",
+      "type": ["null", "string"],
       "deprecationMessage": "Deprecated - use a templateToApp rule instead.",
-      "description": "(Deprecated - use a templateToApp rule instead) Define a single templateToApp rules file for the template."
+      "description": "(Deprecated - use a templateToApp rule instead) Define a single templateToApp rules file for the template.",
+      "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
     },
     "uiDefinition": {
-      "type": "string",
-      "description": "Path to the UI information file."
+      "type": ["null", "string"],
+      "description": "Path to the UI information file.",
+      "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
     },
     "variableDefinition": {
-      "type": "string",
-      "description": "Path to the variables definition file."
+      "type": ["null", "string"],
+      "description": "Path to the variables definition file.",
+      "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
     },
     "folderDefinition": {
-      "type": "string",
-      "description": "Path to the folder definition file."
+      "type": ["null", "string"],
+      "description": "Path to the folder definition file.",
+      "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
     },
     "apexCallback": {
       "type": "object",
@@ -235,9 +249,10 @@
       ]
     },
     "dashboards": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "List of dashboards to include in the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -256,8 +271,12 @@
             "description": "The dashboard name which MUST match the 'name' attribute in the dashboard file."
           },
           "condition": {
-            "type": "string",
-            "description": "If this is met, then the dashboard will be created in the app; otherwise, it will not be created."
+            "type": ["null", "string"],
+            "description": "If this is met, then the dashboard will be created in the app; otherwise, it will not be created.",
+            "defaultSnippets": [
+              { "label": "\"\"", "body": "${0}" },
+              { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+            ]
           },
           "overwriteOnUpgrade": {
             "$ref": "#/definitions/overwriteOnUpgrade"
@@ -276,9 +295,10 @@
       }
     },
     "lenses": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "List of lenses to include in the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -297,8 +317,12 @@
             "description": "The lens name which MUST match the 'name' attribute in the lens file."
           },
           "condition": {
-            "type": "string",
-            "description": "If this is met, then the lens will be created in the app; otherwise, it will not be created."
+            "type": ["null", "string"],
+            "description": "If this is met, then the lens will be created in the app; otherwise, it will not be created.",
+            "defaultSnippets": [
+              { "label": "\"\"", "body": "${0}" },
+              { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+            ]
           },
           "overwriteOnUpgrade": {
             "$ref": "#/definitions/overwriteOnUpgrade"
@@ -317,9 +341,10 @@
       }
     },
     "eltDataflows": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "List of dataflows to include in the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -338,8 +363,12 @@
             "description": "The dataflow name which MUST match the 'name' attribute in the dataflow file."
           },
           "condition": {
-            "type": "string",
-            "description": "If this is met, then the dataflow will be created in the app; otherwise, it will not be created."
+            "type": ["null", "string"],
+            "description": "If this is met, then the dataflow will be created in the app; otherwise, it will not be created.",
+            "defaultSnippets": [
+              { "label": "\"\"", "body": "${0}" },
+              { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+            ]
           },
           "overwriteOnUpgrade": {
             "$ref": "#/definitions/overwriteOnUpgrade"
@@ -358,11 +387,12 @@
       }
     },
     "recipes": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "List of recipes to include in the template.",
       "$comment": "For now, allow this to be specified, but do not offer it in code-completions until the feature is ready",
       "doNotSuggest": true,
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -381,8 +411,12 @@
             "description": "The recipe name which MUST match the 'name' attribute in the recipe file."
           },
           "condition": {
-            "type": "string",
-            "description": "If this is met, then the recipe will be created in the app; otherwise, it will not be created."
+            "type": ["null", "string"],
+            "description": "If this is met, then the recipe will be created in the app; otherwise, it will not be created.",
+            "defaultSnippets": [
+              { "label": "\"\"", "body": "${0}" },
+              { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+            ]
           },
           "overwriteOnUpgrade": {
             "$ref": "#/definitions/overwriteOnUpgrade"
@@ -401,17 +435,19 @@
       }
     },
     "externalFiles": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "List of external files, CSV and descriptive files to be used in the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
         "required": ["name", "type"],
         "properties": {
           "file": {
-            "type": "string",
-            "description": "Path to the file."
+            "type": ["null", "string"],
+            "description": "Path to the file.",
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           },
           "type": {
             "type": "string",
@@ -424,19 +460,25 @@
             "description": "The externalFile name, which ,iust match the 'name' attribute in the schema file."
           },
           "schema": {
-            "type": "string",
-            "description": "Path to the schema file (describes the format of the data)."
+            "type": ["null", "string"],
+            "description": "Path to the schema file (describes the format of the data).",
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           },
           "userXmd": {
-            "type": "string",
-            "description": "Path to the XMD file (describes the display format of the data)."
+            "type": ["null", "string"],
+            "description": "Path to the XMD file (describes the display format of the data).",
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           },
           "condition": {
-            "type": "string",
-            "description": "If this is met, then the external file will be created in the app; otherwise, it will not be created."
+            "type": ["null", "string"],
+            "description": "If this is met, then the external file will be created in the app; otherwise, it will not be created.",
+            "defaultSnippets": [
+              { "label": "\"\"", "body": "${0}" },
+              { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+            ]
           },
           "rows": {
-            "type": "number",
+            "type": ["null", "number"],
             "default": 5,
             "minimum": 1,
             "maximum": 1000,
@@ -446,9 +488,10 @@
             "$ref": "#/definitions/overwriteOnUpgrade"
           },
           "label": {
-            "type": "string",
+            "type": ["null", "string"],
             "$comment": "Technnically supported but not used in runtime",
-            "doNotSuggest": true
+            "doNotSuggest": true,
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           }
         },
         "defaultSnippets": [
@@ -466,9 +509,10 @@
       }
     },
     "datasetFiles": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "List of datasets to be used in the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -483,20 +527,26 @@
             "description": "The dataset name."
           },
           "userXmd": {
-            "type": "string",
-            "description": "Path to the XMD file for the dataset."
+            "type": ["null", "string"],
+            "description": "Path to the XMD file for the dataset.",
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           },
           "condition": {
-            "type": "string",
-            "description": "If this is met, then the dataset will be created in the app; otherwise, it will not be created."
+            "type": ["null", "string"],
+            "description": "If this is met, then the dataset will be created in the app; otherwise, it will not be created.",
+            "defaultSnippets": [
+              { "label": "\"\"", "body": "${0}" },
+              { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+            ]
           },
           "overwriteOnUpgrade": {
             "$ref": "#/definitions/overwriteOnUpgrade"
           },
           "file": {
-            "type": "string",
+            "type": ["null", "string"],
             "$comment": "Technnically supported but not used in runtime",
-            "doNotSuggest": true
+            "doNotSuggest": true,
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           }
         },
         "defaultSnippets": [
@@ -512,9 +562,10 @@
       }
     },
     "imageFiles": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "List of app images to be used in the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -529,16 +580,21 @@
             "description": "The image name."
           },
           "condition": {
-            "type": "string",
-            "description": "If this is met, then the dataset will be created in the app; otherwise, it will not be created."
+            "type": ["null", "string"],
+            "description": "If this is met, then the dataset will be created in the app; otherwise, it will not be created.",
+            "defaultSnippets": [
+              { "label": "\"\"", "body": "${0}" },
+              { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+            ]
           },
           "overwriteOnUpgrade": {
             "$ref": "#/definitions/overwriteOnUpgrade"
           },
           "label": {
-            "type": "string",
+            "type": ["null", "string"],
             "$comment": "Technnically supported but not used in runtime",
-            "doNotSuggest": true
+            "doNotSuggest": true,
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           }
         },
         "defaultSnippets": [
@@ -546,7 +602,6 @@
             "label": "New imageFile",
             "body": {
               "file": "images/${1:name}.${2|png,jpg,gif,svg|}",
-              "label": "${1}",
               "name": "${1}"
             }
           }
@@ -554,9 +609,10 @@
       }
     },
     "storedQueries": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "List of storied queries to use in the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -575,8 +631,12 @@
             "description": "The stored query name."
           },
           "condition": {
-            "type": "string",
-            "description": "If this is met, then the stored query will be created in the app; otherwise, it will not be created."
+            "type": ["null", "string"],
+            "description": "If this is met, then the stored query will be created in the app; otherwise, it will not be created.",
+            "defaultSnippets": [
+              { "label": "\"\"", "body": "${0}" },
+              { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+            ]
           },
           "overwriteOnUpgrade": {
             "$ref": "#/definitions/overwriteOnUpgrade"
@@ -595,9 +655,9 @@
       }
     },
     "extendedTypes": {
-      "type": "object",
+      "type": ["null", "object"],
       "description": "",
-      "$comment": "this how you do a Map<String, SomeObject[]> in json-schema",
+      "examples": [{}],
       "additionalProperties": {
         "type": "array",
         "description": "The list of named extended types",
@@ -620,8 +680,12 @@
               "description": "The extended type name."
             },
             "condition": {
-              "type": "string",
-              "description": "If this is met, then the extended type will be created in the app; otherwise, it will not be created."
+              "type": ["null", "string"],
+              "description": "If this is met, then the extended type will be created in the app; otherwise, it will not be created.",
+              "defaultSnippets": [
+                { "label": "\"\"", "body": "${0}" },
+                { "label": "${...} expression", "body": "${Variables.${1:varname}}" }
+              ]
             },
             "overwriteOnUpgrade": {
               "$ref": "#/definitions/overwriteOnUpgrade"
@@ -655,9 +719,10 @@
       ]
     },
     "customAttributes": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "Define custom meta data attributes for the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -683,7 +748,8 @@
             ]
           },
           "values": {
-            "type": "array",
+            "type": ["null", "array"],
+            "examples": [[]],
             "items": {
               "type": "string"
             }
@@ -701,9 +767,10 @@
       }
     },
     "videos": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "Associate online videos to the template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -738,9 +805,10 @@
       }
     },
     "tags": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "Keywords to tag on this template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "string"
       },
@@ -752,26 +820,29 @@
       ]
     },
     "templateDependencies": {
-      "type": "array",
+      "type": ["null", "array"],
       "description": "Other templates that this template depends upon. For each, an application will need to exist that was created from the dependent template.",
       "minItems": 0,
+      "examples": [[]],
       "items": {
         "type": "object",
         "additionalProperties": false,
         "required": ["name"],
         "properties": {
           "namespace": {
-            "type": "string",
-            "description": "The dependent template namespace."
+            "type": ["null", "string"],
+            "description": "The dependent template namespace.",
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           },
           "name": {
             "type": "string",
             "description": "The dependent template name."
           },
           "templateVersion": {
-            "type": "string",
+            "type": ["null", "string"],
             "description": "The version matcher of the dependent template this template requires. You can optionally use =, >, >=, <, and <= at beginning.",
-            "pattern": "^(=|>|>=|<|<=)?[0-9]+(\\.[0-9]+)?$"
+            "pattern": "^(=|>|>=|<|<=)?[0-9]+(\\.[0-9]+)?$",
+            "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           }
         },
         "defaultSnippets": [
@@ -793,8 +864,9 @@
       "required": ["name"],
       "properties": {
         "namespace": {
-          "type": "string",
-          "description": "The icon namespace."
+          "type": ["null", "string"],
+          "description": "The icon namespace.",
+          "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
         },
         "name": {
           "type": "string",
@@ -816,8 +888,9 @@
       "required": ["name", "label"],
       "properties": {
         "namespace": {
-          "type": "string",
-          "description": "The icon namespace."
+          "type": ["null", "string"],
+          "description": "The icon namespace.",
+          "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
         },
         "name": {
           "type": "string",
@@ -828,8 +901,9 @@
           "description": "The display label of the template preview."
         },
         "description": {
-          "type": "string",
-          "description": "The description of the template preview."
+          "type": ["null", "string"],
+          "description": "The description of the template preview.",
+          "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
         }
       },
       "defaultSnippets": [
@@ -852,7 +926,8 @@
       "oneOf": [
         {
           "$ref": "#/definitions/elExpression",
-          "patternErrorMessage": "Value must be either a valid ${...} expression, or one of 'Always', 'IfDifferent', or 'Never'"
+          "patternErrorMessage": "Value must be either a valid ${...} expression, or one of 'Always', 'IfDifferent', or 'Never'",
+          "defaultSnippets": [{ "label": "${...} expression", "body": "${Variables.${1:varname}}" }]
         },
         {
           "type": "string",
@@ -863,6 +938,9 @@
             "Overwrite this object on upgrade if it differs from the template's version.",
             "Never overwrite this object on upgrade."
           ]
+        },
+        {
+          "type": "null"
         }
       ]
     }

--- a/extensions/analyticsdx-vscode-templates/test/unit/schema/testfiles/template-info/valid/all-null-inner-fields.json
+++ b/extensions/analyticsdx-vscode-templates/test/unit/schema/testfiles/template-info/valid/all-null-inner-fields.json
@@ -1,0 +1,121 @@
+{
+  // Note: if any more fields are made nullable, update templateInfoSchema.tests.ts as well
+  "label": "AppForTemplate",
+  "name": "AppForTemplate",
+  "assetVersion": 47.0,
+  "releaseInfo": {
+    "templateVersion": "1.1"
+  },
+  "externalFiles": [
+    {
+      "name": "name",
+      "file": null,
+      "type": "CSV",
+      "schema": null,
+      "userXmd": null,
+      "condition": null,
+      "rows": null,
+      "overwriteOnUpgrade": null,
+      "label": null
+    }
+  ],
+  "lenses": [
+    {
+      "file": "lenses/name.json",
+      "label": "name",
+      "name": "name",
+      "condition": null,
+      "overwriteOnUpgrade": null
+    }
+  ],
+  "dashboards": [
+    {
+      "file": "dashboards/name.json",
+      "label": "name",
+      "name": "name",
+      "condition": null,
+      "overwriteOnUpgrade": null
+    }
+  ],
+  "eltDataflows": [
+    {
+      "file": "dataflows/name.json",
+      "label": "name",
+      "name": "name",
+      "condition": null,
+      "overwriteOnUpgrade": null
+    }
+  ],
+  "recipes": [
+    {
+      "file": "recipes/name.json",
+      "label": "name",
+      "name": "name",
+      "condition": null,
+      "overwriteOnUpgrade": null
+    }
+  ],
+  "datasetFiles": [
+    {
+      "label": "name",
+      "name": "name",
+      "userXmd": null,
+      "condition": null,
+      "overwriteOnUpgrade": null,
+      "file": null
+    }
+  ],
+  "storedQueries": [
+    {
+      "file": "queries/name.json",
+      "label": "name",
+      "name": "name",
+      "condition": null,
+      "overwriteOnUpgrade": null
+    }
+  ],
+  "imageFiles": [
+    {
+      "file": "images/name.png",
+      "name": "name",
+      "condition": null,
+      "overwriteOnUpgrade": null,
+      "label": null
+    }
+  ],
+  "extendedTypes": {
+    "stories": [
+      {
+        "file": "name.json",
+        "label": "name",
+        "name": "name",
+        "condition": null,
+        "overwriteOnUpgrade": null
+      }
+    ]
+  },
+  "icons": {
+    "appBadge": {
+      "name": "name",
+      "namespace": null
+    },
+    "templateBadge": {
+      "name": "name",
+      "namespace": null
+    },
+    "templatePreviews": null
+  },
+  "customAttributes": [
+    {
+      "label": "Features",
+      "values": null
+    }
+  ],
+  "templateDependencies": [
+    {
+      "name": "name",
+      "templateVersion": null,
+      "namespace": null
+    }
+  ]
+}

--- a/extensions/analyticsdx-vscode-templates/test/unit/schema/testfiles/template-info/valid/all-null-top-fields.json
+++ b/extensions/analyticsdx-vscode-templates/test/unit/schema/testfiles/template-info/valid/all-null-top-fields.json
@@ -1,0 +1,33 @@
+{
+  // Note: if any more fields are made nullable, update templateInfoSchema.tests.ts as well
+  "templateType": null,
+  "label": "AppForTemplate",
+  "name": "AppForTemplate",
+  "description": null,
+  "assetVersion": 47.0,
+  "variableDefinition": null,
+  "uiDefinition": null,
+  "rules": null,
+  "ruleDefinition": null,
+  "assetIcon": null,
+  "templateIcon": null,
+  "releaseInfo": {
+    "templateVersion": "1.1",
+    "notesFile": null
+  },
+  "folderDefinition": null,
+  "externalFiles": null,
+  "lenses": null,
+  "dashboards": null,
+  "eltDataflows": null,
+  "recipes": null,
+  "datasetFiles": null,
+  "storedQueries": null,
+  "imageFiles": null,
+  "extendedTypes": null,
+  "icons": null,
+  "customAttributes": null,
+  "videos": null,
+  "tags": null,
+  "templateDependencies": null
+}

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/schemas/templateInfoSchema.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/schemas/templateInfoSchema.test.ts
@@ -6,62 +6,96 @@
  */
 
 import { expect } from 'chai';
+import { findNodeAtLocation, JSONPath, parseTree } from 'jsonc-parser';
+import { posix as path } from 'path';
 import * as vscode from 'vscode';
-import { scanLinesUntil } from '../../../src/util/vscodeUtils';
+import { jsonPathToString } from '../../../src/util/jsoncUtils';
+import { scanLinesUntil, uriStat } from '../../../src/util/vscodeUtils';
 import {
   closeAllEditors,
+  createTempTemplate,
   getCompletionItems,
+  openFile,
   openTemplateInfo,
   openTemplateInfoAndWaitForDiagnostics,
   setDocumentText,
-  waitForDiagnostics
+  waitForDiagnostics,
+  writeTextToFile
 } from '../vscodeTestUtils';
 
 // tslint:disable:no-unused-expression
 describe('template-info-schema.json hookup', () => {
-  beforeEach(closeAllEditors);
-  afterEach(closeAllEditors);
+  async function verifyCompletionsContain(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    ...expectedLabels: string[]
+  ) {
+    const list = await getCompletionItems(document.uri, position);
+    const labels = list.items.map(item => item.label);
+    expect(labels, 'completion items').to.include.members(expectedLabels);
+    // also we shouldn't get any duplicate code completion items (which can come if something else, like the default
+    // json language service, is injecting extra stuff into our document type).
+    const dups: string[] = [];
+    list.items
+      .reduce((m, val) => m.set(val.label, (m.get(val.label) || 0) + 1), new Map<string, number>())
+      .forEach((num, label) => {
+        if (num >= 2) {
+          dups.push(label);
+        }
+      });
+    if (dups.length > 0) {
+      expect.fail('Found duplicate completion items: ' + dups.join(', '));
+    }
+  }
 
-  // this is really just testing that vscode is picking up our schema on template-info.json's --
-  // these diagnostics comes from vscode
-  it('shows problems on empty file', async () => {
-    const [diagnostics] = await openTemplateInfoAndWaitForDiagnostics(
-      'emptyTemplateInfo',
-      true,
-      d => d && d.length >= 4
-    );
-    // we should get a warning about needing 1 dashboard/dataflow/dataset on the root object from the linter,
-    // so just filter that out for now
-    const map = new Map(diagnostics.filter(d => d.message.startsWith('Missing property ')).map(d => [d.message, d]));
-    // there should be a warning for each these fields being missing
-    ['name', 'label', 'assetVersion', 'releaseInfo'].forEach(name => {
-      const d = map.get('Missing property "' + name + '".');
-      expect(d, name + ' diagnostic missing').to.be.not.undefined;
-      expect(d!.severity, name + ' diagnostic severity').to.be.equals(vscode.DiagnosticSeverity.Warning);
-      map.delete(d!.message);
+  describe('shows problems on', () => {
+    beforeEach(closeAllEditors);
+    afterEach(closeAllEditors);
+
+    // this is really just testing that vscode is picking up our schema on template-info.json's --
+    // these diagnostics comes from vscode
+    it('empty file', async () => {
+      const [diagnostics] = await openTemplateInfoAndWaitForDiagnostics(
+        'emptyTemplateInfo',
+        true,
+        d => d && d.length >= 4
+      );
+      // we should get a warning about needing 1 dashboard/dataflow/dataset on the root object from the linter,
+      // so just filter that out for now
+      const map = new Map(diagnostics.filter(d => d.message.startsWith('Missing property ')).map(d => [d.message, d]));
+      // there should be a warning for each these fields being missing
+      ['name', 'label', 'assetVersion', 'releaseInfo'].forEach(name => {
+        const d = map.get('Missing property "' + name + '".');
+        expect(d, name + ' diagnostic missing').to.be.not.undefined;
+        expect(d!.severity, name + ' diagnostic severity').to.be.equals(vscode.DiagnosticSeverity.Warning);
+        map.delete(d!.message);
+      });
+      if (map.size !== 0) {
+        expect.fail(
+          'Got ' + map.size + ' unexpected diangotics:\n' + JSON.stringify(Array.from(map.values()), undefined, 2)
+        );
+      }
     });
-    if (map.size !== 0) {
-      expect.fail(
-        'Got ' + map.size + ' unexpected diangotics:\n' + JSON.stringify(Array.from(map.values()), undefined, 2)
-      );
-    }
-  });
 
-  it('shows problems on Simple_Dashboard template', async () => {
-    const [diagnostics] = await openTemplateInfoAndWaitForDiagnostics('Simple_Dashboard');
-    if (diagnostics.length !== 1) {
-      expect.fail(
-        'Expected 1 diagnostic, got ' + diagnostics.length + ':\n' + JSON.stringify(diagnostics, undefined, 2)
+    it('Simple_Dashboard template', async () => {
+      const [diagnostics] = await openTemplateInfoAndWaitForDiagnostics('Simple_Dashboard');
+      if (diagnostics.length !== 1) {
+        expect.fail(
+          'Expected 1 diagnostic, got ' + diagnostics.length + ':\n' + JSON.stringify(diagnostics, undefined, 2)
+        );
+      }
+      expect(diagnostics[0].message, 'diagnostic message').to.be.equals(
+        "Deprecated - use 'icons.templateBadge' instead."
       );
-    }
-    expect(diagnostics[0].message, 'diagnostic message').to.be.equals(
-      "Deprecated - use 'icons.templateBadge' instead."
-    );
-    // this is also testing the positive case for linter.js's file-path checks since there are no warnings about them,
-    // and that the allowComments: true in the schema works in VSCode
-  });
+      // this is also testing the positive case for linter.js's file-path checks since there are no warnings about them,
+      // and that the allowComments: true in the schema works in VSCode
+    });
+  }); // describe('shows problems on')
 
   describe('has snippet for', () => {
+    beforeEach(closeAllEditors);
+    afterEach(closeAllEditors);
+
     async function testCompletions(docText: string, scanForChar: string, scanStartLine: number, expectedLabel: string) {
       const [document, editor] = await openTemplateInfo('empty');
       expect(editor, 'editor').to.not.be.undefined;
@@ -117,5 +151,206 @@ describe('template-info-schema.json hookup', () => {
     it('icons.templatePreviews', async () => {
       await testCompletions('{\n  "icons": {\n    "templatePreviews": []\n  }\n}', '[', 2, 'New icon');
     });
-  });
+  }); // describe('has snippet for')
+
+  describe('has completions for nullable field', () => {
+    let tmpdir: vscode.Uri | undefined;
+    let doc: vscode.TextDocument | undefined;
+    // we don't need values on anything since we're only looking at completions; also,
+    // we need all the top-level fields, but only the subfields that have completions that
+    // come from the schema (templateEditing.test.ts will test the dynamic completions)
+    const json: any = {
+      templateType: 'app',
+      description: null,
+      variableDefinition: null,
+      uiDefinition: null,
+      ruleDefinition: null,
+      assetIcon: null,
+      templateIcon: null,
+      folderDefinition: null,
+      releaseInfo: {
+        notesFile: null
+      },
+      rules: null,
+      externalFiles: [
+        {
+          file: null,
+          schema: null,
+          userXmd: null,
+          condition: null,
+          rows: null,
+          overwriteOnUpgrade: null,
+          label: null
+        }
+      ],
+      lenses: [
+        {
+          condition: null,
+          overwriteOnUpgrade: null
+        }
+      ],
+      dashboards: [
+        {
+          condition: null,
+          overwriteOnUpgrade: null
+        }
+      ],
+      eltDataflows: [
+        {
+          condition: null,
+          overwriteOnUpgrade: null
+        }
+      ],
+      recipes: [
+        {
+          condition: null,
+          overwriteOnUpgrade: null
+        }
+      ],
+      datasetFiles: [
+        {
+          userXmd: null,
+          condition: null,
+          overwriteOnUpgrade: null,
+          file: null
+        }
+      ],
+      storedQueries: [
+        {
+          condition: null,
+          overwriteOnUpgrade: null
+        }
+      ],
+      imageFiles: [
+        {
+          condition: null,
+          overwriteOnUpgrade: null,
+          label: null
+        }
+      ],
+      extendedTypes: {
+        stories: [
+          {
+            condition: null,
+            overwriteOnUpgrade: null
+          }
+        ]
+      },
+      icons: {
+        appBadge: {
+          namespace: null
+        },
+        templateBadge: {
+          namespace: null
+        },
+        templatePreviews: [
+          {
+            description: null
+          }
+        ]
+      },
+      customAttributes: [
+        {
+          values: null
+        }
+      ],
+      templateDependencies: [
+        {
+          templateVersion: null,
+          namespace: null
+        }
+      ],
+      videos: null,
+      tags: null
+    };
+
+    before(async () => {
+      await closeAllEditors();
+      [tmpdir] = await createTempTemplate(false);
+      const templateInfo = tmpdir.with({ path: path.join(tmpdir.path, 'template-info.json') });
+      await writeTextToFile(templateInfo, json);
+      [doc] = await openFile(templateInfo);
+    });
+    after(async () => {
+      if (tmpdir && (await uriStat(tmpdir))) {
+        await vscode.workspace.fs.delete(tmpdir, { recursive: true, useTrash: false });
+      }
+      tmpdir = undefined;
+      doc = undefined;
+    });
+
+    // make a test for each of these fields to make sure it has the expected completion items
+    [
+      { jsonpath: ['templateType'] as JSONPath, completions: ['"app"', '"dashboard"', '"embeddedapp"'] },
+      { jsonpath: ['variableDefinition'], completions: ['""'] },
+      { jsonpath: ['uiDefinition'], completions: ['""'] },
+      { jsonpath: ['ruleDefinition'], completions: ['""'] },
+      { jsonpath: ['assetIcon'], completions: ['""'] },
+      { jsonpath: ['templateIcon'], completions: ['""'] },
+      { jsonpath: ['folderDefinition'], completions: ['""'] },
+      { jsonpath: ['releaseInfo', 'notesFile'], completions: ['""'] },
+      { jsonpath: ['rules'], completions: ['[]', 'New rules'] },
+      { jsonpath: ['externalFiles'], completions: ['[]'] },
+      { jsonpath: ['externalFiles', 0, 'file'], completions: ['""'] },
+      { jsonpath: ['externalFiles', 0, 'schema'], completions: ['""'] },
+      { jsonpath: ['externalFiles', 0, 'userXmd'], completions: ['""'] },
+      { jsonpath: ['externalFiles', 0, 'condition'], completions: ['""', '${...} expression'] },
+      { jsonpath: ['externalFiles', 0, 'rows'], completions: ['5'] },
+      { jsonpath: ['externalFiles', 0, 'overwriteOnUpgrade'], completions: ['${...} expression'] },
+      { jsonpath: ['lenses'], completions: ['[]'] },
+      { jsonpath: ['lenses', 0, 'condition'], completions: ['""', '${...} expression'] },
+      { jsonpath: ['lenses', 0, 'overwriteOnUpgrade'], completions: ['${...} expression'] },
+      { jsonpath: ['dashboards'], completions: ['[]'] },
+      { jsonpath: ['dashboards', 0, 'condition'], completions: ['""', '${...} expression'] },
+      { jsonpath: ['dashboards', 0, 'overwriteOnUpgrade'], completions: ['${...} expression'] },
+      { jsonpath: ['eltDataflows'], completions: ['[]'] },
+      { jsonpath: ['eltDataflows', 0, 'condition'], completions: ['""', '${...} expression'] },
+      { jsonpath: ['eltDataflows', 0, 'overwriteOnUpgrade'], completions: ['${...} expression'] },
+      { jsonpath: ['recipes'], completions: ['[]'] },
+      { jsonpath: ['recipes', 0, 'condition'], completions: ['""', '${...} expression'] },
+      { jsonpath: ['recipes', 0, 'overwriteOnUpgrade'], completions: ['${...} expression'] },
+      { jsonpath: ['datasetFiles'], completions: ['[]'] },
+      { jsonpath: ['datasetFiles', 0, 'userXmd'], completions: ['""'] },
+      { jsonpath: ['datasetFiles', 0, 'condition'], completions: ['""', '${...} expression'] },
+      { jsonpath: ['datasetFiles', 0, 'overwriteOnUpgrade'], completions: ['${...} expression'] },
+      { jsonpath: ['datasetFiles', 0, 'file'], completions: ['""'] },
+      { jsonpath: ['storedQueries'], completions: ['[]'] },
+      { jsonpath: ['storedQueries', 0, 'condition'], completions: ['""', '${...} expression'] },
+      { jsonpath: ['storedQueries', 0, 'overwriteOnUpgrade'], completions: ['${...} expression'] },
+      { jsonpath: ['imageFiles'], completions: ['[]'] },
+      { jsonpath: ['imageFiles', 0, 'condition'], completions: ['""', '${...} expression'] },
+      { jsonpath: ['imageFiles', 0, 'overwriteOnUpgrade'], completions: ['${...} expression'] },
+      { jsonpath: ['imageFiles', 0, 'label'], completions: ['""'] },
+      { jsonpath: ['extendedTypes'], completions: ['{}', 'New extendedTypes'] },
+      { jsonpath: ['extendedTypes', 'stories', 0, 'condition'], completions: ['""', '${...} expression'] },
+      {
+        jsonpath: ['extendedTypes', 'stories', 0, 'overwriteOnUpgrade'],
+        completions: ['${...} expression']
+      },
+      { jsonpath: ['icons'], completions: ['{}'] },
+      { jsonpath: ['icons', 'appBadge', 'namespace'], completions: ['""'] },
+      { jsonpath: ['icons', 'templateBadge', 'namespace'], completions: ['""'] },
+      { jsonpath: ['icons', 'templatePreviews', 0, 'description'], completions: ['""'] },
+      { jsonpath: ['customAttributes'], completions: ['[]'] },
+      { jsonpath: ['customAttributes', 0, 'values'], completions: ['[]'] },
+      { jsonpath: ['templateDependencies'], completions: ['[]'] },
+      { jsonpath: ['templateDependencies', 0, 'namespace'], completions: ['""'] },
+      { jsonpath: ['templateDependencies', 0, 'templateVersion'], completions: ['""'] },
+      { jsonpath: ['videos'], completions: ['[]'] },
+      { jsonpath: ['tags'], completions: ['[]', 'New tags'] }
+    ].forEach(({ jsonpath, completions }) => {
+      const jsonPathStr = jsonPathToString(jsonpath);
+      it(jsonPathStr, async () => {
+        const tree = parseTree(doc!.getText());
+        expect(tree, 'json node').to.not.be.undefined;
+        // go to the field
+        const node = findNodeAtLocation(tree, jsonpath);
+        expect(node, jsonPathStr).to.not.be.undefined;
+        // go to right after the ":"
+        const position = doc!.positionAt(node!.parent!.colonOffset! + 1);
+        // that should give a snippet to fill out the whole featuresAssets
+        await verifyCompletionsContain(doc!, position, 'null', ...completions);
+      });
+    });
+  }); // describe('has completions for nullable field')
 });

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/vscodeTestUtils.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/vscodeTestUtils.ts
@@ -212,12 +212,24 @@ export async function createTempTemplate(
   if (!open) {
     return [dir, undefined, undefined];
   }
-  const [doc, editor] = await openTemplateInfo(dir, show);
+  const [doc, editor] = await openTemplateInfo(file, show);
   return [dir, doc, editor];
 }
 
+export function writeTextToFile(file: vscode.Uri, textOrObj: string | object): Thenable<void> {
+  const text = typeof textOrObj === 'string' ? textOrObj : JSON.stringify(textOrObj, undefined, 2);
+  const len = text.length;
+  // 2 bytes for each unicde char
+  const buf = new ArrayBuffer(len * 2);
+  const view = new Uint16Array(buf);
+  for (let i = 0; i < len; i++) {
+    view[i] = text.charCodeAt(i);
+  }
+  return vscode.workspace.fs.writeFile(file, new Uint8Array(buf));
+}
+
 export function writeEmptyJsonFile(file: vscode.Uri): Thenable<void> {
-  return vscode.workspace.fs.writeFile(file, Uint8Array.from([123, 125]));
+  return writeTextToFile(file, '{}');
 }
 
 export function findPositionByJsonPath(doc: vscode.TextDocument, path: JSONPath): vscode.Position | undefined {


### PR DESCRIPTION
Once you allow null in a json-schema on otherwise string types, VSCode stops
doing the default text-based hippy completion for the fields; it also doesn't
offer the type-specific empty value (e.g. "", [], {}) when null is allowed.
So, this adds in those empty values, via either "examples" or "defaultSnippets"
in the schema.