### PR TITLE
Add telemetry when a quick fix or relpath code completion is used

### DIFF
--- a/extensions/analyticsdx-vscode-core/package.json
+++ b/extensions/analyticsdx-vscode-core/package.json
@@ -71,6 +71,7 @@
     "onCommand:analyticsdx.app.delete",
     "onCommand:analyticsdx.studio.open",
     "onCommand:analyticsdx.studio.open.app",
+    "onCommand:analyticsdx.telemetry.send",
     "onCommand:analyticsdx.template.create",
     "onCommand:analyticsdx.template.delete",
     "onCommand:analyticsdx.template.udpate"

--- a/extensions/analyticsdx-vscode-core/src/index.ts
+++ b/extensions/analyticsdx-vscode-core/src/index.ts
@@ -17,6 +17,19 @@ import {
   updateTemplate
 } from './commands';
 
+function sendTelemetryCommand(
+  eventName: string,
+  extensionName: string,
+  properties?: {
+    [key: string]: string;
+  }
+) {
+  if (eventName && extensionName) {
+    // Note: we're intentionally not waiting for this to finish
+    telemetryService.sendTelemetryEvent(eventName, extensionName, properties).catch(console.error);
+  }
+}
+
 export function activate(context: ExtensionContext) {
   const extensionHRStart = process.hrtime();
 
@@ -34,7 +47,10 @@ export function activate(context: ExtensionContext) {
     commands.registerCommand('analyticsdx.studio.open.app', openAppInStudio),
     commands.registerCommand('analyticsdx.template.create', createTemplate),
     commands.registerCommand('analyticsdx.template.delete', deleteTemplate),
-    commands.registerCommand('analyticsdx.template.update', updateTemplate)
+    commands.registerCommand('analyticsdx.template.update', updateTemplate),
+    // Note: analyticsdx.telemetry.send is intentionally not listed in package.json; it's only for extension
+    // code to call
+    commands.registerCommand('analyticsdx.telemetry.send', sendTelemetryCommand)
   );
 
   console.log('Analytics DX CLI Extension Activated');

--- a/extensions/analyticsdx-vscode-core/src/telemetry/telemetry.ts
+++ b/extensions/analyticsdx-vscode-core/src/telemetry/telemetry.ts
@@ -58,6 +58,20 @@ export class TelemetryService {
     this.reporter = reporter;
   }
 
+  /** Send a custom telemetry event */
+  public async sendTelemetryEvent(
+    eventName: string,
+    extensionName: string,
+    properties: {
+      [key: string]: string;
+    } = {}
+  ) {
+    await this.setupVSCodeTelemetry();
+    if (this.reporter !== undefined && this.isTelemetryEnabled) {
+      this.reporter.sendTelemetryEvent(eventName, Object.assign(properties || {}, { extensionName }));
+    }
+  }
+
   public async sendExtensionActivationEvent(hrstart: [number, number]): Promise<void> {
     await this.setupVSCodeTelemetry();
     if (this.reporter !== undefined && this.isTelemetryEnabled) {


### PR DESCRIPTION
to see if anyone ends up using them.