### PR TITLE
Warn on duplicate relative paths configured in a template

### DIFF
--- a/extensions/analyticsdx-vscode-templates/src/constants.ts
+++ b/extensions/analyticsdx-vscode-templates/src/constants.ts
@@ -21,7 +21,7 @@ export const htmlFileFilter = newFileExtensionFilter('html', 'htm');
 export const imageFileFilter = newFileExtensionFilter('png', 'jpg', 'gif', 'svg');
 export const csvFileFilter = newFileExtensionFilter('csv');
 
-const jsonPats = [
+const definitionFilesPats = [
   ['variableDefinition'] as JSONPath,
   ['uiDefinition'],
   ['folderDefinition'],
@@ -30,11 +30,14 @@ const jsonPats = [
   ['dashboards', '*', 'file'],
   ['lenses', '*', 'file'],
   ['eltDataflows', '*', 'file'],
+  ['storedQueries', '*', 'file'],
+  ['extendedTypes', '*', '*', 'file']
+];
+const jsonPats = [
+  ...definitionFilesPats,
   ['externalFiles', '*', 'schema'],
   ['externalFiles', '*', 'userXmd'],
-  ['storedQueries', '*', 'file'],
-  ['datasetFiles', '*', 'userXmd'],
-  ['extendedTypes', '*', '*', 'file']
+  ['datasetFiles', '*', 'userXmd']
 ];
 const htmlPats = [['releaseInfo', 'notesFile'] as JSONPath];
 const imagePats = [['imageFiles', '*', 'file'] as JSONPath];
@@ -44,6 +47,11 @@ const csvPats = [['externalFiles', '*', 'file'] as JSONPath];
  * Constants related to template-info.json files.
  */
 export const TEMPLATE_INFO = Object.freeze({
+  /** JSONPaths to attributes that are relative-paths to object definition files.
+   * Generally, these should not be referenced more than once in a template.
+   */
+  definitionFilePathLocationPatterns: Object.freeze(definitionFilesPats),
+
   /**
    * JSONPaths to attributes that should be relative-paths to other json files.
    */

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing.test.ts
@@ -250,10 +250,11 @@ describe('TemplateEditorManager', () => {
             list.items.map(item => item.detail || item.label).join(', ')
         );
       }
+      return list.items;
     }
 
     it('json file completions', async () => {
-      await testCompletions(
+      const completions = await testCompletions(
         TEMPLATE_INFO.jsonRelFilePathLocationPatterns[0],
         'dashboards/dashboard.json',
         'dataflows/dataflow.json',
@@ -262,6 +263,13 @@ describe('TemplateEditorManager', () => {
         'queries/query.json'
         // there's other json files in the template dir, but if we see these, then it's hooked up
       );
+      // make sure the completions don't include 'template-info.json'
+      if (completions.some(item => item.detail === 'template-info.json')) {
+        expect.fail(
+          'Completions should be not contain template-info.json, got: ' +
+            completions.map(item => item.detail || item.label)
+        );
+      }
     });
 
     it('html file completions', async () => {


### PR DESCRIPTION
With the way we do the schema assignment, the relpath file will get that last schema configured, which might not give the best warnings, but the warning in template-info.json should be enough to point out that something's wrong.
Also, no relpath should be 'template-info.json' nor should that appear in the code completions, since that will never be valid.