### PR TITLE
Switch duplicate rule warning to hints

### DIFF
--- a/extensions/analyticsdx-vscode-templates/src/templateLinter.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateLinter.ts
@@ -167,7 +167,8 @@ export class TemplateLinter {
     relatedMessage?: string | ((value: string, doc: vscode.TextDocument, node: JsonNode) => string),
     computeValue: (node: JsonNode, doc: vscode.TextDocument) => string | undefined = node => {
       return node.type === 'string' && typeof node.value === 'string' ? node.value : undefined;
-    }
+    },
+    severity = vscode.DiagnosticSeverity.Warning
   ) {
     // value -> list of doc+node's w/ that value
     const values = new Map<string, Array<{ doc: vscode.TextDocument; node: JsonNode }>>();
@@ -195,7 +196,8 @@ export class TemplateLinter {
           const diagnostic = this.addDiagnostic(
             doc,
             typeof message === 'string' ? message : message(value, doc, node),
-            node
+            node,
+            severity
           );
           // create related information for the other locations
           if (relatedMessage) {
@@ -622,7 +624,14 @@ export class TemplateLinter {
     // make sure the constants' names are unique
     this.lintUniqueValues(sources, ['constants', '*', 'name'], name => `Duplicate constant '${name}'`, 'Other usage');
     // make sure the rules' names are unique
-    this.lintUniqueValues(sources, ['rules', '*', 'name'], name => `Duplicate rule name '${name}'`, 'Other usage');
+    this.lintUniqueValues(
+      sources,
+      ['rules', '*', 'name'],
+      name => `Duplicate rule name '${name}'`,
+      'Other usage',
+      undefined,
+      vscode.DiagnosticSeverity.Hint
+    );
     // make sure macro namespace:name is unique
     this.lintUniqueValues(
       sources,

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateLinter.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateLinter.test.ts
@@ -987,7 +987,7 @@ describe('TemplateLinterManager', () => {
       );
     });
 
-    it('shows problems on duplicate rule names', async () => {
+    it('shows hints on duplicate rule names', async () => {
       const rulesJson = {
         rules: [
           {
@@ -1102,7 +1102,7 @@ describe('TemplateLinterManager', () => {
         await waitForDiagnostics(
           rulesEditor.document.uri,
           d => d && d.length >= 3,
-          'Initial ' + uriBasename(rulesEditor.document.uri) + ' duplicate rule names warnings'
+          'Initial ' + uriBasename(rulesEditor.document.uri) + ' duplicate rule names hints'
         )
       ).sort(sortDiagnostics);
       if (diagnostics.length !== 3) {
@@ -1113,6 +1113,7 @@ describe('TemplateLinterManager', () => {
       expect(diagnostic, 'diagnostic[0]').to.not.be.undefined;
       expect(diagnostic.message, 'diagnostic[0].message').to.equal("Duplicate rule name 'name1'");
       expect(diagnostic.code, 'diagnostic[0].code').to.equal('rules[0].name');
+      expect(diagnostic.severity, 'diagnostic[0].severity').to.equal(vscode.DiagnosticSeverity.Hint);
       expect(diagnostic.relatedInformation?.length, 'diagnostic[0].relatedInformation.length').to.equal(1);
       expect(diagnostic.relatedInformation?.[0].message, 'diagnostic[0].relatedInformation.message').to.equal(
         'Other usage'
@@ -1129,6 +1130,7 @@ describe('TemplateLinterManager', () => {
       expect(diagnostic, 'diagnostic[1]').to.not.be.undefined;
       expect(diagnostic.message, 'diagnostic[1].message').to.equal("Duplicate rule name 'name3'");
       expect(diagnostic.code, 'diagnostic[1].code').to.equal('rules[1].name');
+      expect(diagnostic.severity, 'diagnostic[1].severity').to.equal(vscode.DiagnosticSeverity.Hint);
       expect(diagnostic.relatedInformation?.length, 'diagnostic[1].relatedInformation.length').to.equal(1);
       expect(diagnostic.relatedInformation?.[0].message, 'diagnostic[1].relatedInformation.message').to.equal(
         'Other usage'
@@ -1141,6 +1143,7 @@ describe('TemplateLinterManager', () => {
       expect(diagnostic, 'diagnostic[2]').to.not.be.undefined;
       expect(diagnostic.message, 'diagnostic[2].message').to.equal("Duplicate rule name 'name1'");
       expect(diagnostic.code, 'diagnostic[2].code').to.equal('rules[2].name');
+      expect(diagnostic.severity, 'diagnostic[2].severity').to.equal(vscode.DiagnosticSeverity.Hint);
       expect(diagnostic.relatedInformation?.length, 'diagnostic[2].relatedInformation.length').to.equal(1);
       expect(diagnostic.relatedInformation?.[0].message, 'diagnostic[2].relatedInformation.message').to.equal(
         'Other usage'
@@ -1158,7 +1161,7 @@ describe('TemplateLinterManager', () => {
         await waitForDiagnostics(
           rules2Editor.document.uri,
           d => d && d.length >= 1,
-          'Initial ' + uriBasename(rules2Editor.document.uri) + ' duplicate rule names warnings'
+          'Initial ' + uriBasename(rules2Editor.document.uri) + ' duplicate rule names hints'
         )
       ).sort(sortDiagnostics);
       if (diagnostics.length !== 1) {
@@ -1181,7 +1184,7 @@ describe('TemplateLinterManager', () => {
       await waitForDiagnostics(
         rules3Editor.document.uri,
         d => d && d.length === 0,
-        'No warnings on ' + uriBasename(rules3Editor.document.uri)
+        'No hints on ' + uriBasename(rules3Editor.document.uri)
       );
 
       // fix the duplicate rule names
@@ -1191,17 +1194,17 @@ describe('TemplateLinterManager', () => {
       await waitForDiagnostics(
         rulesEditor.document.uri,
         d => d && d.length === 0,
-        'No warnings on ' + uriBasename(rulesEditor.document.uri) + ' after fixing duplicate rule names'
+        'No hints on ' + uriBasename(rulesEditor.document.uri) + ' after fixing duplicate rule names'
       );
       await waitForDiagnostics(
         rules2Editor.document.uri,
         d => d && d.length === 0,
-        'No warnings on ' + uriBasename(rules2Editor.document.uri) + ' after fixing duplicate rule names'
+        'No hints on ' + uriBasename(rules2Editor.document.uri) + ' after fixing duplicate rule names'
       );
       await waitForDiagnostics(
         rules3Editor.document.uri,
         d => d && d.length === 0,
-        'No warnings on ' + uriBasename(rules3Editor.document.uri)
+        'No hints on ' + uriBasename(rules3Editor.document.uri)
       );
     });
 


### PR DESCRIPTION
since it's not really required that it be unique, it's just a nice to know.

Hints show as a small underline in the editor, but don't show in the Problems view (unlike Informations). I think it looks nice and stays out of the way if you're not interested in it. You can hover it see all the details (like the other usages of the rule name).