### PR TITLE
Make apexCallback.namespace optional

### DIFF
--- a/extensions/analyticsdx-vscode-templates/schemas/template-info-schema.json
+++ b/extensions/analyticsdx-vscode-templates/schemas/template-info-schema.json
@@ -283,11 +283,11 @@
       "type": "object",
       "description": "Registers an Apex class that runs on wizard load, app create, and app upgrade. The Apex class examines the org and sets variable values.",
       "additionalProperties": false,
-      "required": ["namespace", "name"],
+      "required": ["name"],
       "properties": {
         "namespace": {
           "type": "string",
-          "description": "The SFDC namespace for the org."
+          "description": "The SFDC namespace for the org, if the org has a namespace."
         },
         "name": {
           "type": "string",
@@ -299,8 +299,7 @@
         {
           "label": "New apexCallback",
           "body": {
-            "namespace": "${1:namespace}",
-            "name": "${2:name}"
+            "name": "${1:name}"
           }
         }
       ]

--- a/extensions/analyticsdx-vscode-templates/test/unit/schema/invalidTemplateInfoJsonTests.ts
+++ b/extensions/analyticsdx-vscode-templates/test/unit/schema/invalidTemplateInfoJsonTests.ts
@@ -133,7 +133,6 @@ describe('template-info-schema.json finds errors in', () => {
       'customAttributes[0].label',
       'templateDependencies[0].name',
       'apexCallback.name',
-      'apexCallback.namespace',
       'videos[0].purpose',
       'videos[0].id',
       'videos[0].linkType',


### PR DESCRIPTION
You only need it for namespaced cases, like templates in managed packages.
