### PR TITLE
Add code-completions for new variables

### DIFF
--- a/extensions/analyticsdx-vscode-templates/schemas/variables-schema.json
+++ b/extensions/analyticsdx-vscode-templates/schemas/variables-schema.json
@@ -58,20 +58,20 @@
           "type": "string",
           "description": "Variable type.",
           "enum": [
+            "ArrayType",
             "BooleanType",
-            "StringType",
-            "NumberType",
-            "SobjectType",
-            "SobjectFieldType",
-            "DateTimeType",
-            "DatasetType",
+            "ConnectorType",
+            "DatasetAnyFieldType",
+            "DatasetDateType",
             "DatasetDimensionType",
             "DatasetMeasureType",
-            "DatasetDateType",
-            "DatasetAnyFieldType",
-            "ArrayType",
+            "DatasetType",
+            "DateTimeType",
+            "NumberType",
             "ObjectType",
-            "ConnectorType"
+            "SobjectType",
+            "SobjectFieldType",
+            "StringType"
           ]
         },
         "enums": {

--- a/extensions/analyticsdx-vscode-templates/src/autoInstall/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/autoInstall/completions.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { findNodeAtLocation, Location, Node as JsonNode } from 'jsonc-parser';
+import * as vscode from 'vscode';
+import { TemplateDirEditing } from '../templateEditing';
+import { isValidRelpath } from '../util/utils';
+import { VariableRefCompletionItemProviderDelegate } from '../variables';
+
+function zeropad(n: number, len = 2) {
+  let s = n.toFixed(0); // we can ignore negatives & decimals since this is for date values
+  const need = len - s.length;
+  for (let i = 0; i < need; i++) {
+    s = '0' + s;
+  }
+  return s;
+}
+
+// convert a date.getTimezoneOffset to an ISO8601 numeric tz
+function toTzStr(offset: number) {
+  // Date.getTimezoneOffset() is a neg offset, so use the opposite sign in the is08601 string
+  const sign = offset < 0 ? '+' : '-';
+  offset = Math.abs(offset);
+  const hours = Math.floor(offset / 60);
+  const mins = offset % 60;
+  return sign + zeropad(hours) + zeropad(mins);
+}
+
+/** Provide completions items for variables references in configuration.appConfiguration.values */
+export class AutoInstallVariableCompletionItemProviderDelegate extends VariableRefCompletionItemProviderDelegate {
+  constructor(templateEditing: TemplateDirEditing) {
+    super(templateEditing);
+  }
+
+  public isSupportedDocument(document: vscode.TextDocument) {
+    return (
+      isValidRelpath(this.templateEditing.variablesDefinitionPath) &&
+      this.templateEditing.isAutoInstallDefinitionFile(document.uri)
+    );
+  }
+
+  public isSupportedLocation(location: Location) {
+    return (
+      location.isAtPropertyKey &&
+      location.matches(['configuration', 'appConfiguration', 'values', '*']) &&
+      // this makes sure the completion only show in prop names directly under "values" (and not in prop names in object
+      // values under "values")
+      location.path.length === 4
+    );
+  }
+
+  protected createVariableCompletionItem(
+    range: vscode.Range | undefined,
+    document: vscode.TextDocument,
+    varname: string,
+    varDefNode: JsonNode | undefined
+  ): vscode.CompletionItem {
+    const item = super.createVariableCompletionItem(range, document, varname, varDefNode);
+    // if this isn't replacing an existing property name, add a ': <empty value>' after the varname
+    if (!range || range.isEmpty) {
+      item.label = `"${item.label}"`;
+      item.insertText = this.appendDefaultValue(new vscode.SnippetString(`"${varname}": `), varDefNode);
+    }
+    return item;
+  }
+
+  private appendDefaultValue(insertText: vscode.SnippetString, varDefNode: JsonNode | undefined): vscode.SnippetString {
+    if (varDefNode?.type === 'object') {
+      const typeNode = findNodeAtLocation(varDefNode, ['variableType', 'type']);
+      const type = typeNode?.type === 'string' && typeof typeNode.value === 'string' ? typeNode.value : undefined;
+      if (type === 'ArrayType') {
+        insertText
+          .appendText('[')
+          .appendTabstop()
+          .appendText(']');
+      } else if (type === 'BooleanType') {
+        insertText.appendChoice(['true', 'false']);
+      } else if (type === 'DatasetAnyFieldType' || type === 'DatasetDimensionType' || type === 'DatasetMeasureType') {
+        insertText
+          .appendText('{\n\t"datasetId": "')
+          .appendTabstop()
+          .appendText('",\n\t"fieldName": "')
+          .appendTabstop()
+          .appendText('"\n}');
+      } else if (type === 'DatasetDateType') {
+        insertText
+          .appendText('{\n\t"datasetId": "')
+          .appendTabstop()
+          .appendText('",\n\t"dateAlias": "')
+          .appendTabstop()
+          .appendText('"\n}');
+      } else if (type === 'DatasetType') {
+        insertText
+          .appendText('{\n\t"datasetId": "')
+          .appendTabstop()
+          .appendText('"\n}');
+      } else if (type === 'NumberType') {
+        insertText.appendPlaceholder('0');
+      } else if (type === 'ObjectType') {
+        insertText
+          .appendText('{')
+          .appendTabstop()
+          .appendText('}');
+      } else if (type === 'SobjectType') {
+        insertText
+          .appendText('{\n\t"sobjectName": "')
+          .appendTabstop()
+          .appendText('"\n}');
+      } else if (type === 'SobjectFieldType') {
+        insertText
+          .appendText('{\n\t"sobjectName": "')
+          .appendTabstop()
+          .appendText('",\n\t"fieldName": "')
+          .appendTabstop()
+          .appendText('"\n}');
+      } else if (type === 'DateTimeType') {
+        const now = new Date();
+        // value needs to be in "yyyy-MM-ddTHH:mm:ssz" format (or a number for UTC secs)
+        insertText
+          .appendText('"')
+          .appendPlaceholder(zeropad(now.getFullYear(), 4))
+          .appendText('-')
+          .appendPlaceholder(zeropad(now.getMonth() + 1))
+          .appendText('-')
+          .appendPlaceholder(zeropad(now.getDate()))
+          .appendText('T')
+          .appendPlaceholder(zeropad(now.getHours()))
+          .appendText(':')
+          .appendPlaceholder(zeropad(now.getMinutes()))
+          .appendText(':')
+          .appendPlaceholder(zeropad(now.getSeconds()))
+          .appendPlaceholder(toTzStr(now.getTimezoneOffset()))
+          .appendText('"');
+      } else {
+        // for no type in var def or anything else, assume a string value -- this covers StringType and ConnectorType
+        // and no type specified (which is StringType);
+        // it also means unknown/invalid types get a string value, which matches what we do for the hover -- they'll have an
+        // error in their variables json file
+        insertText
+          .appendText('"')
+          .appendTabstop()
+          .appendText('"');
+      }
+    }
+    // REVIEWME: calculate out if we should add a trailing-comma? Typescript doesn't (like in array and object literals)
+    // but would be nice
+    return insertText.appendTabstop(0);
+  }
+}

--- a/extensions/analyticsdx-vscode-templates/src/autoInstall/index.ts
+++ b/extensions/analyticsdx-vscode-templates/src/autoInstall/index.ts
@@ -6,5 +6,6 @@
  */
 
 export * from './actions';
+export * from './completions';
 export * from './definitions';
 export * from './hovers';

--- a/extensions/analyticsdx-vscode-templates/src/ui/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/ui/completions.ts
@@ -5,90 +5,31 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { findNodeAtLocation, Location, parseTree } from 'jsonc-parser';
+import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
-import { codeCompletionUsedTelemetryCommand } from '../telemetry';
 import { TemplateDirEditing } from '../templateEditing';
-import { JsonAttributeCompletionItemProviderDelegate, newCompletionItem } from '../util/completions';
-import { isValidVariableName } from '../util/templateUtils';
 import { isValidRelpath } from '../util/utils';
-import { uriRelPath } from '../util/vscodeUtils';
+import { VariableRefCompletionItemProviderDelegate } from '../variables';
 
 /** Get variable names for the variable name in the pages in ui.json. */
-export class UiVariableCompletionItemProviderDelegate implements JsonAttributeCompletionItemProviderDelegate {
-  constructor(private readonly templateEditing: TemplateDirEditing) {}
+export class UiVariableCompletionItemProviderDelegate extends VariableRefCompletionItemProviderDelegate {
+  constructor(templateEditing: TemplateDirEditing) {
+    super(templateEditing);
+  }
 
-  public supported(
-    location: Location,
-    document: vscode.TextDocument,
-    token: vscode.CancellationToken,
-    context: vscode.CompletionContext
-  ): boolean {
+  public isSupportedDocument(document: vscode.TextDocument): boolean {
     return (
-      // make sure it's in the uiDefinition file for the template
-      this.templateEditing.isUiDefinitionFile(document.uri) &&
-      // and that the template has a variableDefinition
+      // make sure that the template has a variableDefinition
       isValidRelpath(this.templateEditing.variablesDefinitionPath) &&
-      // and that it's in a variable name field
-      location.matches(['pages', '*', 'variables', '*', 'name'])
+      // and that it's in the uiDefinition file for the template
+      this.templateEditing.isUiDefinitionFile(document.uri)
     );
   }
 
-  public async items(
-    range: vscode.Range | undefined,
-    location: Location,
-    document: vscode.TextDocument,
-    token: vscode.CancellationToken,
-    context: vscode.CompletionContext
-  ): Promise<vscode.CompletionItem[]> {
-    // pull the variables names from the variables file
-    const varUri = uriRelPath(this.templateEditing.dir, this.templateEditing.variablesDefinitionPath!);
-    const doc = await vscode.workspace.openTextDocument(varUri);
-    const tree = parseTree(doc.getText());
-    const items: vscode.CompletionItem[] = [];
-    if (tree.type === 'object') {
-      tree.children?.forEach(child => {
-        if (
-          child.type === 'property' &&
-          child.children?.[0]?.type === 'string' &&
-          typeof child.children[0].value === 'string' &&
-          child.children[0].value &&
-          isValidVariableName(child.children[0].value)
-        ) {
-          const item = newCompletionItem(child.children[0].value, range, vscode.CompletionItemKind.Variable);
-          // try to pull the variable type, label and description to add to the completion item
-          if (child.children?.[1]?.type === 'object') {
-            // put '(type) label' in the detail
-            const typeNode = findNodeAtLocation(child.children[1], ['variableType', 'type']);
-            let type =
-              typeNode?.type === 'string' && typeof typeNode.value === 'string' && typeNode.value
-                ? typeNode.value
-                : 'StringType';
-            if (type === 'ArrayType') {
-              // try to unwrap to the array item type
-              const itemsType = findNodeAtLocation(child.children[1], ['variableType', 'itemsType', 'type']);
-              if (itemsType?.type === 'string' && typeof itemsType.value === 'string' && itemsType.value) {
-                type = `${itemsType.value}[]`;
-              }
-            }
-            item.detail = `(${type})`;
-            const label = findNodeAtLocation(child.children[1], ['label']);
-            if (label?.type === 'string' && typeof label.value === 'string' && label.value) {
-              item.detail += ' ' + label.value;
-            }
-
-            // put the description in the documentation
-            const desc = findNodeAtLocation(child.children[1], ['description']);
-            if (desc?.type === 'string' && typeof desc.value === 'string' && desc.value) {
-              item.documentation = desc.value;
-            }
-          }
-          // send telemetry when someone accepts the completion item
-          item.command = codeCompletionUsedTelemetryCommand(item.label, 'variable', location.path, document.uri);
-          items.push(item);
-        }
-      });
-    }
-    return items;
+  public isSupportedLocation(location: Location, context: vscode.CompletionContext): boolean {
+    return (
+      // make that it's in a variable name value
+      !location.isAtPropertyKey && location.matches(['pages', '*', 'variables', '*', 'name'])
+    );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/util/actions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/util/actions.ts
@@ -17,7 +17,7 @@ import { quickFixUsedTelemetryCommand } from '../telemetry';
 import { findPropertyNodeFor, jsonPathToString, pathPartsAreEquals } from './jsoncUtils';
 import { findEditorForDocument, getFormattingOptionsForEditor, jsonEditsToWorkspaceEdit } from './vscodeUtils';
 
-// TODO: refactor this into a master (which does the parse) and delegates,
+// TODO: refactor this into a controller (which does the parse) and delegates,
 // to avoid parsing the json multiple times and to register only one action provider
 export class RemoveJsonPropertyCodeActionProvider implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];

--- a/extensions/analyticsdx-vscode-templates/src/variables/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/variables/completions.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { findNodeAtLocation, Location, Node as JsonNode, parseTree } from 'jsonc-parser';
+import * as vscode from 'vscode';
+import { codeCompletionUsedTelemetryCommand } from '../telemetry';
+import { TemplateDirEditing } from '../templateEditing';
+import { JsonCompletionItemProviderDelegate, newCompletionItem } from '../util/completions';
+import { isValidVariableName } from '../util/templateUtils';
+import { uriRelPath } from '../util/vscodeUtils';
+
+export const NEW_VARIABLE_SNIPPETS = Object.freeze([
+  { label: 'New array variable', type: 'ArrayType' },
+  { label: 'New boolean variable', type: 'BooleanType' },
+  { label: 'New number variable', type: 'NumberType' },
+  { label: 'New string variable', type: 'StringType' },
+  { label: 'New variable', type: '' }
+]);
+
+/** Provider completion items to add new variable definitions to the variableDefinition file. */
+export class NewVariableCompletionItemProviderDelegate implements JsonCompletionItemProviderDelegate {
+  constructor(private readonly templateEditing: TemplateDirEditing) {}
+
+  public isSupportedDocument(document: vscode.TextDocument) {
+    return this.templateEditing.isVariablesDefinitionFile(document.uri);
+  }
+
+  public isSupportedLocation(location: Location) {
+    return (
+      // make sure it's in the empty part of the variables.json {}
+      location.isAtPropertyKey && location.matches(['*']) && location.path.length === 1
+    );
+  }
+
+  public getItems(
+    range: vscode.Range | undefined,
+    location: Location,
+    document: vscode.TextDocument
+  ): vscode.CompletionItem[] | undefined {
+    // if the range will be non-empty if the cursor is in an existing "varname", in which case we don't want to give
+    // any completions
+    if (range?.isEmpty) {
+      return NEW_VARIABLE_SNIPPETS.map(({ label, type }) => {
+        // tabs and newlines in the snippet text will get appropriately replaced in the editor
+        const snippet = new vscode.SnippetString()
+          .appendText('"')
+          .appendTabstop()
+          .appendText('": {\n\t"variableType": {\n\t\t"type": "')
+          .appendPlaceholder(type)
+          .appendText('"');
+        if (type === 'ArrayType') {
+          snippet
+            .appendText(',\n\t\t"itemsType": {\n\t\t\t"type": "')
+            .appendTabstop()
+            .appendText('"\n\t\t}');
+        }
+        snippet.appendText('\n\t}\n}').appendTabstop(0);
+        // REVIEWME: calculate if this needs a trailing comma? typescript doesn't seem to in array/object literals,
+        // but it would be nice
+
+        const item = newCompletionItem(label, range, vscode.CompletionItemKind.Variable, undefined, snippet);
+        item.command = codeCompletionUsedTelemetryCommand(item.label, 'new-variable', location.path, document.uri, {
+          vartype: type
+        });
+        return item;
+      });
+    }
+  }
+}
+/** Get variable completions for variable ref fields in files. */
+export abstract class VariableRefCompletionItemProviderDelegate implements JsonCompletionItemProviderDelegate {
+  constructor(protected readonly templateEditing: TemplateDirEditing) {}
+
+  public abstract isSupportedDocument(document: vscode.TextDocument): boolean;
+
+  public abstract isSupportedLocation(location: Location, context: vscode.CompletionContext): boolean;
+
+  protected createVariableCompletionItem(
+    range: vscode.Range | undefined,
+    document: vscode.TextDocument,
+    varname: string,
+    varDefNode: JsonNode | undefined
+  ): vscode.CompletionItem {
+    const item = newCompletionItem(varname, range, vscode.CompletionItemKind.Variable);
+    // try to pull the variable type, label and description to add to the completion item
+    if (varDefNode?.type === 'object') {
+      // put '(type) label' in the detail
+      const typeNode = findNodeAtLocation(varDefNode, ['variableType', 'type']);
+      let type =
+        typeNode?.type === 'string' && typeof typeNode.value === 'string' && typeNode.value
+          ? typeNode.value
+          : 'StringType';
+      if (type === 'ArrayType') {
+        // try to unwrap to the array item type
+        const itemsType = findNodeAtLocation(varDefNode, ['variableType', 'itemsType', 'type']);
+        if (itemsType?.type === 'string' && typeof itemsType.value === 'string' && itemsType.value) {
+          type = `${itemsType.value}[]`;
+        }
+      }
+      item.detail = `(${type})`;
+      const label = findNodeAtLocation(varDefNode, ['label']);
+      if (label?.type === 'string' && typeof label.value === 'string' && label.value) {
+        item.detail += ' ' + label.value;
+      }
+
+      // put the description in the documentation
+      const desc = findNodeAtLocation(varDefNode, ['description']);
+      if (desc?.type === 'string' && typeof desc.value === 'string' && desc.value) {
+        item.documentation = desc.value;
+      }
+    }
+    return item;
+  }
+
+  public async getItems(
+    range: vscode.Range | undefined,
+    location: Location,
+    document: vscode.TextDocument
+  ): Promise<vscode.CompletionItem[]> {
+    // pull the variables names from the variables file
+    const varUri = uriRelPath(this.templateEditing.dir, this.templateEditing.variablesDefinitionPath!);
+    const doc = await vscode.workspace.openTextDocument(varUri);
+    const tree = parseTree(doc.getText());
+    const items: vscode.CompletionItem[] = [];
+    if (tree.type === 'object') {
+      tree.children?.forEach(child => {
+        if (
+          child.type === 'property' &&
+          child.children?.[0]?.type === 'string' &&
+          typeof child.children[0].value === 'string' &&
+          child.children[0].value &&
+          isValidVariableName(child.children[0].value)
+        ) {
+          const item = this.createVariableCompletionItem(range, document, child.children[0].value, child.children[1]);
+          // send telemetry when someone accepts the completion item
+          item.command = codeCompletionUsedTelemetryCommand(item.label, 'variable', location.path, document.uri);
+          items.push(item);
+        }
+      });
+    }
+    return items;
+  }
+}

--- a/extensions/analyticsdx-vscode-templates/src/variables/index.ts
+++ b/extensions/analyticsdx-vscode-templates/src/variables/index.ts
@@ -6,5 +6,6 @@
  */
 
 export * from './actions';
+export * from './completions';
 export * from './definitions';
 export * from './hover';


### PR DESCRIPTION
This required some refactoring of the completions code to support fetching completions on fields' property locations, and also allowed for doing completions in auto-install values.