### PR TITLE
Fix json language server in vscode 1.47+

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,6 +67,28 @@ jobs:
           sudo /usr/bin/Xvfb :10 -ac -screen 0 1024x768x24 -audit 4 2>&1 &
           DISPLAY=:10 npm test
 
+  build-insiders:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.4.0
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.4.0'
+      - name: Build
+        run: |
+          npm install
+          npm run compile
+      - name: Tests
+        # start X virtual frame buffer so tests can do ui
+        run: |
+          sudo /usr/bin/Xvfb :10 -ac -screen 0 1024x768x24 -audit 4 2>&1 &
+          DISPLAY=:10 npm run test:vscode-insiders-integration
+
   build-windows:
     runs-on: windows-latest
 

--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -28,6 +28,28 @@ jobs:
           sudo /usr/bin/Xvfb :10 -ac -screen 0 1024x768x24 -audit 4 2>&1 &
           DISPLAY=:10 npm test
 
+  pr-build-insiders:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.4.0
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.4.0'
+      - name: Build
+        run: |
+          npm install
+          npm run compile
+      - name: Tests
+        # start X virtual frame buffer so tests can do ui
+        run: |
+          sudo /usr/bin/Xvfb :10 -ac -screen 0 1024x768x24 -audit 4 2>&1 &
+          DISPLAY=:10 npm run test:vscode-insiders-integration
+
   # include a windows build job in PRs since mostly folks are developing on linux or mac, so
   # we might not catch windows-specific failures locally as much
   pr-build-windows:

--- a/extensions/analyticsdx-vscode-templates/package.json
+++ b/extensions/analyticsdx-vscode-templates/package.json
@@ -31,7 +31,8 @@
     "lodash.isequal": "4.5.0",
     "request-light": "0.2.4",
     "vscode-extension-telemetry": "0.0.17",
-    "vscode-languageclient": "^5.3.0-next.9"
+    "vscode-json-languageserver": "1.2.3",
+    "vscode-languageclient": "^6.1.3"
   },
   "devDependencies": {
     "@salesforce/analyticsdx-test-utils-vscode": "0.3.0",

--- a/scripts/download-vscode-for-tests.js
+++ b/scripts/download-vscode-for-tests.js
@@ -26,11 +26,10 @@ function symlink(src, dest) {
 // Downloads an instance of VS Code for tests to either .vscode-test/insiders or .vscode-test/stable
 (async function() {
   const installDir = process.env.CODE_VERSION === 'insiders' ? 'insiders' : 'stable';
-  console.log(`#!# Downloading ${installDir}...`);
   const electron = await downloadAndUnzipVSCode(installDir);
   // downloadAndUnzipVSCode generates a path (with a version #) to the Electron executable, like:
-  //   .../.vscode-test/vscode-1.36.1/Visual Studio Code.app/Contents/MacOS/Electron
-  // but our stuff is expecting a .../.vscode-test/stable for stable version, so symlink
+  //   .../.vscode-test/vscode-1.36.1/Visual Studio Code.app/Contents/...
+  // but our stuff is expecting a .../.vscode-test/stable/... for stable version, so symlink
   const vscodeTestDir = path.join(process.cwd(), '.vscode-test');
   // this should give us the top install dir path part of vscode (e.g. 'vscode-1.36.1')
   const reldir = path.relative(vscodeTestDir, electron).split(path.sep)[0];

--- a/scripts/install-vsix-dependency.js
+++ b/scripts/install-vsix-dependency.js
@@ -13,8 +13,7 @@ const fs = require('fs');
 const mkdirp = require('mkdirp');
 
 // Installs a list of extensions passed on the command line
-var version = process.env.CODE_VERSION || '*';
-var isInsiders = version === 'insiders';
+var isInsiders = process.env.CODE_VERSION === 'insiders';
 
 const testRunFolder = path.join('.vscode-test', isInsiders ? 'insiders' : 'stable');
 const testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
@@ -22,17 +21,22 @@ const testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
 const downloadPlatform =
   process.platform === 'darwin' ? 'darwin' : process.platform === 'win32' ? 'win32-archive' : 'linux-x64';
 
-const windowsExecutable = path.join(testRunFolderAbsolute, 'bin', 'code');
+const windowsExecutable = path.join(testRunFolderAbsolute, 'bin', isInsiders ? 'code-insiders' : 'code');
 const darwinExecutable = path.join(
   testRunFolderAbsolute,
-  'Visual Studio Code.app',
+  isInsiders ? 'Visual Studio Code - Insiders.app' : 'Visual Studio Code.app',
   'Contents',
   'Resources',
   'app',
   'bin',
   'code'
 );
-const linuxExecutable = path.join(testRunFolderAbsolute, 'VSCode-linux-x64', 'bin', 'code');
+const linuxExecutable = path.join(
+  testRunFolderAbsolute,
+  'VSCode-linux-x64',
+  'bin',
+  isInsiders ? 'code-insiders' : 'code'
+);
 
 const extensionsDir = path.join('.vscode-test', 'extensions');
 if (!fs.existsSync(extensionsDir)) {
@@ -44,7 +48,7 @@ const executable =
 
 if (process.platform === 'linux') {
   // Somehow the code executable doesn't have +x set on the autobuilds -- set it here
-  shell.chmod('+x', `${executable}`);
+  shell.chmod('+x', executable);
 }
 
 // We always invoke this script with 'node install-vsix-dependency arg ...'


### PR DESCRIPTION
The template json client was failing to start in vscode insiders (1.47) because the json language server code in the included vscode.json-language-features extension changed.
This changes the template extension to use a fixed version of vscode-json-languageserver so we have more control over out interaction with it.
It also fixes the test:vscode-insiders-integration to work again and adds it to the github actions ci builds so we'll know about any failures in the next version of vscode faster.