### PR TITLE
Fix doc and help links in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently, this repository contains source for the following extensions:
 
 - **[analyticsdx-vscode-core](extensions/analyticsdx-vscode-core/README.md)**  
   [This extension](https://marketplace.visualstudio.com/items?itemName=salesforce.analyticsdx-vscode-core) interacts
-  with the [Salesforce CLI Analytics Plugin](https://help.salesforce.com/articleView?id=bi_dev_tools_cli_analytics_plugin.htm&type=5)
+  with the [Salesforce CLI Analytics Plugin](http://sfdc.co/adx_cli_help)
   to provide analytics commands.  
   ![Installs](https://img.shields.io/visual-studio-marketplace/i/salesforce.analyticsdx-vscode-core) ![Downloads](https://img.shields.io/visual-studio-marketplace/d/salesforce.analyticsdx-vscode-core)
 

--- a/extensions/analyticsdx-vscode-core/README.md
+++ b/extensions/analyticsdx-vscode-core/README.md
@@ -19,8 +19,8 @@ If you would like to suggest a feature, create a [feature request on GitHub](htt
 
 - Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
 - Doc: [Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)
-- Doc: [Analytics Plugin for the Salesforce CLI Guide](https://help.salesforce.com/articleView?id=bi_dev_tools_cli_analytics_plugin.htm&type=5)
-- Doc: [Analytics Plugin for the Salesforce CLI Command Reference](https://help.salesforce.com/articleView?id=bi_cli_analytics_plugin_command_reference.htm&type=5)
+- Doc: [Analytics Plugin for the Salesforce CLI Guide](http://sfdc.co/adx_cli_help)
+- Doc: [Analytics Plugin for the Salesforce CLI Command Reference](http://sfdc.co/adx_cli_reference)
 
 ---
 


### PR DESCRIPTION
Switched to short urls in case the underlying urls change in the future. The short urls are also shown when you do `sfdx analytics`.