### PR TITLE
Support null for shares in folder.json

### DIFF
--- a/extensions/analyticsdx-vscode-templates/schemas/folder-schema.json
+++ b/extensions/analyticsdx-vscode-templates/schemas/folder-schema.json
@@ -19,7 +19,7 @@
       "type": ["string", "null"]
     },
     "featuredAssets": {
-      "type": "object",
+      "type": ["object", "null"],
       "description": "Determines the dashboards to feature, and the order in which to list them, in an app created from the template. If empty, app features all dashboards listed in alphabetical order according to label.",
       "required": [],
       "additionalProperties": false,
@@ -86,7 +86,7 @@
       ]
     },
     "shares": {
-      "type": "array",
+      "type": ["array", "null"],
       "minItems": 0,
       "items": {
         "type": "object",

--- a/extensions/analyticsdx-vscode-templates/test/unit/schema/testfiles/folder/valid/with-nested-nulls.json
+++ b/extensions/analyticsdx-vscode-templates/test/unit/schema/testfiles/folder/valid/with-nested-nulls.json
@@ -1,7 +1,4 @@
 {
-  "name": null,
-  "label": null,
-  "description": null,
   "featuredAssets": {
     "default": {
       "assets": [

--- a/extensions/analyticsdx-vscode-templates/test/unit/schema/testfiles/folder/valid/with-top-level-nulls.json
+++ b/extensions/analyticsdx-vscode-templates/test/unit/schema/testfiles/folder/valid/with-top-level-nulls.json
@@ -1,0 +1,7 @@
+{
+  "name": null,
+  "label": null,
+  "description": null,
+  "featuredAssets": null,
+  "shares": null
+}

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/folder.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/folder.test.ts
@@ -89,8 +89,19 @@ describe('TemplateEditorManager configures folderDefinition', () => {
       expect.fail("Expected to find '{' after '\"featuredAssets\":'");
     }
     let position = scan.end.translate({ characterDelta: -1 });
-    // that should give a snippet to fill out the whole featuresAssets
-    await verifyCompletionsContain(doc, position, 'New featuredAssets');
+    // that should give an option for null and  a snippet to fill out the whole featuresAssets
+    await verifyCompletionsContain(doc, position, 'New featuredAssets', 'null');
+
+    // go before after the [ in "shares"
+    node = findNodeAtLocation(tree, ['shares']);
+    expect(node, 'shares').to.not.be.undefined;
+    scan = scanLinesUntil(doc, ch => ch === '[', doc.positionAt(node!.offset));
+    if (scan.ch !== '[') {
+      expect.fail("Expected to find '[' after '\"shares\":'");
+    }
+    position = scan.end.translate({ characterDelta: -1 });
+    // that should give an option for null and a snippet for a new share
+    await verifyCompletionsContain(doc, position, 'New share', 'null');
 
     // go right after the [ in "shares"
     node = findNodeAtLocation(tree, ['shares']);
@@ -100,7 +111,7 @@ describe('TemplateEditorManager configures folderDefinition', () => {
       expect.fail("Expected to find '[' after '\"shares\":'");
     }
     position = scan.end.translate({ characterDelta: 1 });
-    // that should give a snippet for default
+    // that should give a snippet for a new share
     await verifyCompletionsContain(doc, position, 'New share');
     // REVIEWME: we could test for 'New featuresAsset' and 'New shares', but this is enough to make sure the
     // json schema association is there


### PR DESCRIPTION
and featuredAssets. It's not common, but is valid.