### PR TITLE
Fixes to commands for embeddedapp templates

### DIFF
--- a/extensions/analyticsdx-vscode-core/package.json
+++ b/extensions/analyticsdx-vscode-core/package.json
@@ -80,7 +80,8 @@
     "onCommand:analyticsdx.telemetry.send",
     "onCommand:analyticsdx.template.create",
     "onCommand:analyticsdx.template.delete",
-    "onCommand:analyticsdx.template.udpate"
+    "onCommand:analyticsdx.template.udpate",
+    "onCommand:analyticsdx.template.updateFromApp"
   ],
   "main": "./out/src",
   "contributes": {
@@ -120,6 +121,10 @@
       {
         "command": "analyticsdx.template.update",
         "title": "%analyticsdx_template_update_label%"
+      },
+      {
+        "command": "analyticsdx.template.updateFromApp",
+        "title": "%analyticsdx_template_update_from_app_label%"
       }
     ],
     "menus": {
@@ -158,6 +163,10 @@
         },
         {
           "command": "analyticsdx.template.update",
+          "when": "sfdx:project_opened"
+        },
+        {
+          "command": "analyticsdx.template.updateFromApp",
           "when": "sfdx:project_opened"
         }
       ]

--- a/extensions/analyticsdx-vscode-core/package.nls.json
+++ b/extensions/analyticsdx-vscode-core/package.nls.json
@@ -13,5 +13,6 @@
 
   "analyticsdx_template_create_label": "SFDX: Create Analytics Template",
   "analyticsdx_template_delete_label": "SFDX: Delete Analytics Template",
-  "analyticsdx_template_update_label": "SFDX: Update Analytics Template"
+  "analyticsdx_template_update_label": "SFDX: Update Analytics Template",
+  "analyticsdx_template_update_from_app_label": "SFDX: Update Analytics Template From App"
 }

--- a/extensions/analyticsdx-vscode-core/src/commands/createApp.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/createApp.ts
@@ -115,7 +115,10 @@ type TemplateAndName = {
 };
 
 class TemplateAndNameGather implements ParametersGatherer<TemplateAndName> {
-  private readonly templateGatherer = new TemplateGatherer();
+  private readonly templateGatherer = new TemplateGatherer({
+    // sfdx analytics:app:create only works for 'app' templates
+    filter: template => template.templatetype === 'app'
+  });
   public async gather(): Promise<CancelResponse | ContinueResponse<TemplateAndName>> {
     const template = await this.templateGatherer.gather();
     if (template.type === 'CANCEL') {

--- a/extensions/analyticsdx-vscode-core/src/commands/createTemplate.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/createTemplate.ts
@@ -6,12 +6,7 @@
  */
 
 import { nls } from '../messages';
-import {
-  SfdxCommandBuilder,
-  SfdxCommandlet,
-  SfdxCommandletExecutor,
-  sfdxWorkspaceChecker
-} from './commands';
+import { SfdxCommandBuilder, SfdxCommandlet, SfdxCommandletExecutor, sfdxWorkspaceChecker } from './commands';
 import { AppGatherer, AppMetadata } from './gatherers/appGatherer';
 
 class CreateTemplateExecutor extends SfdxCommandletExecutor<AppMetadata> {

--- a/extensions/analyticsdx-vscode-core/src/commands/deleteTemplate.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/deleteTemplate.ts
@@ -30,12 +30,13 @@ class DeleteTemplateExecutor extends SfdxCommandletExecutor<TemplateMetadata> {
 
 const deleteTemplateCommandlet = new SfdxCommandlet(
   sfdxWorkspaceChecker,
-  new TemplateGatherer(
+  new TemplateGatherer({
     // you can only delete templates that don't have an associated app
-    template => !template.folderid,
-    nls.localize('delete_template_cmd_no_templates_message'),
-    nls.localize('delete_template_cmd_placeholder_message')
-  ),
+    filter: template => !template.folderid,
+    includeEmbedded: true,
+    noTemplatesMesg: nls.localize('delete_template_cmd_no_templates_message'),
+    placeholderMesg: nls.localize('delete_template_cmd_placeholder_message')
+  }),
   new DeleteTemplateExecutor(),
   new DeleteObjectPostChecker<TemplateMetadata>(template =>
     nls.localize('delete_template_cmd_confirm_text', template.label || template.name)

--- a/extensions/analyticsdx-vscode-core/src/commands/gatherers/templateGatherer.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/gatherers/templateGatherer.ts
@@ -58,7 +58,7 @@ export type TemplateMetadata = {
   namespace?: string | null;
 };
 
-class TemplateQuickPickItem implements vscode.QuickPickItem {
+export class TemplateQuickPickItem implements vscode.QuickPickItem {
   constructor(readonly template: TemplateMetadata) {}
 
   get label() {
@@ -77,7 +77,7 @@ class TemplateQuickPickItem implements vscode.QuickPickItem {
 }
 
 type TemplateFilter = (template: TemplateMetadata) => boolean;
-type TemplateGatherOptions = TemplateListExecutorOptions & {
+export type TemplateGatherOptions = TemplateListExecutorOptions & {
   filter?: TemplateFilter;
   noTemplatesMesg?: string;
   placeholderMesg?: string;
@@ -106,7 +106,7 @@ export class TemplateGatherer implements ParametersGatherer<TemplateMetadata> {
     this.fetchMesg = fetchMesg;
   }
 
-  public async gather(): Promise<CancelResponse | ContinueResponse<TemplateMetadata>> {
+  public async loadQuickPickItems(): Promise<TemplateQuickPickItem[]> {
     const templateListCommandlet = new SfdxCommandletWithOutput(
       sfdxWorkspaceChecker,
       emptyParametersGatherer,
@@ -121,6 +121,11 @@ export class TemplateGatherer implements ParametersGatherer<TemplateMetadata> {
         .filter(this.filter || (() => true))
         .map(template => new TemplateQuickPickItem(template));
     }
+    return items;
+  }
+
+  public async gather(): Promise<CancelResponse | ContinueResponse<TemplateMetadata>> {
+    const items = await this.loadQuickPickItems();
     if (items.length <= 0) {
       notificationService.showInformationMessage(this.noTemplatesMesg);
       return { type: 'CANCEL' };

--- a/extensions/analyticsdx-vscode-core/src/commands/updateTemplate.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/updateTemplate.ts
@@ -27,12 +27,13 @@ class UpdateTemplateExecutor extends SfdxCommandletExecutor<TemplateMetadata> {
 
 const updateTemplateCommandlet = new SfdxCommandlet(
   sfdxWorkspaceChecker,
-  // only show templates that have an associated app
-  new TemplateGatherer(
-    template => !!template.folderid,
-    nls.localize('update_template_cmd_no_apps_message'),
-    nls.localize('update_template_cmd_placeholder_message')
-  ),
+  new TemplateGatherer({
+    // only show templates that have an associated app
+    filter: template => !!template.folderid,
+    includeEmbedded: true,
+    noTemplatesMesg: nls.localize('update_template_cmd_no_apps_message'),
+    placeholderMesg: nls.localize('update_template_cmd_placeholder_message')
+  }),
   new UpdateTemplateExecutor()
 );
 

--- a/extensions/analyticsdx-vscode-core/src/commands/updateTemplate.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/updateTemplate.ts
@@ -4,15 +4,29 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as vscode from 'vscode';
 import { nls } from '../messages';
-import { SfdxCommandBuilder, SfdxCommandlet, SfdxCommandletExecutor, sfdxWorkspaceChecker } from './commands';
+import {
+  CancelResponse,
+  ContinueResponse,
+  notificationService,
+  SfdxCommandBuilder,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  sfdxWorkspaceChecker
+} from './commands';
+import { AppGatherer, AppQuickPickItem } from './gatherers/appGatherer';
 import { TemplateGatherer, TemplateMetadata } from './gatherers/templateGatherer';
 
 class UpdateTemplateExecutor extends SfdxCommandletExecutor<TemplateMetadata> {
+  constructor(private readonly description: string) {
+    super();
+  }
+
   public build(data: TemplateMetadata) {
     return (
       new SfdxCommandBuilder()
-        .withDescription(nls.localize('update_template_cmd_message'))
+        .withDescription(this.description)
         .withArg('analytics:template:update')
         .withArg('-t')
         .withArg(data.templateid)
@@ -31,12 +45,73 @@ const updateTemplateCommandlet = new SfdxCommandlet(
     // only show templates that have an associated app
     filter: template => !!template.folderid,
     includeEmbedded: true,
-    noTemplatesMesg: nls.localize('update_template_cmd_no_apps_message'),
+    noTemplatesMesg: nls.localize('update_template_cmd_no_templates_message'),
     placeholderMesg: nls.localize('update_template_cmd_placeholder_message')
   }),
-  new UpdateTemplateExecutor()
+  new UpdateTemplateExecutor(nls.localize('update_template_cmd_message'))
 );
 
 export async function updateTemplate() {
   await updateTemplateCommandlet.run();
+}
+
+class TemplateAndFolderGatherer extends TemplateGatherer {
+  public async gather(): Promise<CancelResponse | ContinueResponse<TemplateMetadata>> {
+    // get all the templates and the apps that came from templates at the same time, and have the user pick a template
+    const [templateResponse, allAppItems] = await Promise.all([
+      super.gather(),
+      new AppGatherer(app => !!app.templateSourceId).loadQuickPickItems()
+    ]);
+    if (templateResponse.type === 'CANCEL') {
+      return templateResponse;
+    }
+
+    // find the current app for the template (if any), and any apps that came from that template
+    let currentAppItem: AppQuickPickItem | undefined = undefined;
+    const matchingAppItems: AppQuickPickItem[] = [];
+    for (const item of allAppItems) {
+      if (templateResponse.data.folderid && item.app.folderid === templateResponse.data.folderid) {
+        currentAppItem = item;
+      } else if (item.app.templateSourceId === templateResponse.data.templateid) {
+        matchingAppItems.push(item);
+      }
+    }
+    if (!currentAppItem && matchingAppItems.length <= 0) {
+      // TODO: add an option to create a new app from the template and use that as the source app
+      notificationService.showInformationMessage(nls.localize('update_template_from_app_cmd_no_apps_message'));
+      return { type: 'CANCEL' };
+    }
+
+    // put the template's current app first in the list so it's the default selection
+    if (currentAppItem) {
+      currentAppItem.detail = nls.localize('update_template_from_app_cmd_current_app_details');
+      matchingAppItems.unshift(currentAppItem);
+    }
+    const appResponse = await vscode.window.showQuickPick(matchingAppItems, {
+      matchOnDescription: true,
+      placeHolder: nls.localize('app_gatherer_def_placeholder_message'),
+      matchOnDetail: true
+    });
+    if (!appResponse) {
+      return { type: 'CANCEL' };
+    }
+
+    // set the selected folderid onto the TemplateMetadata to pass to the executor
+    templateResponse.data.folderid = appResponse.app.folderid;
+    return { type: 'CONTINUE', data: templateResponse.data };
+  }
+}
+
+const updateTemplateFromAppCommandlet = new SfdxCommandlet(
+  sfdxWorkspaceChecker,
+  new TemplateAndFolderGatherer({
+    includeEmbedded: true,
+    noTemplatesMesg: nls.localize('update_template_from_app_cmd_no_templates_message'),
+    placeholderMesg: nls.localize('update_template_from_app_cmd_placeholder_message')
+  }),
+  new UpdateTemplateExecutor(nls.localize('update_template_from_app_cmd_message'))
+);
+
+export async function updateTemplateFromApp() {
+  await updateTemplateFromAppCommandlet.run();
 }

--- a/extensions/analyticsdx-vscode-core/src/index.ts
+++ b/extensions/analyticsdx-vscode-core/src/index.ts
@@ -18,7 +18,8 @@ import {
   openAppInStudio,
   openDataManager,
   openStudio,
-  updateTemplate
+  updateTemplate,
+  updateTemplateFromApp
 } from './commands';
 import { checkAnalyticsSfdxPlugin } from './util/sfdx';
 
@@ -61,6 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('analyticsdx.template.create', createTemplate),
     vscode.commands.registerCommand('analyticsdx.template.delete', deleteTemplate),
     vscode.commands.registerCommand('analyticsdx.template.update', updateTemplate),
+    vscode.commands.registerCommand('analyticsdx.template.updateFromApp', updateTemplateFromApp),
     // Note: analyticsdx.telemetry.send is intentionally not listed in package.json; it's only for extension
     // code to call
     vscode.commands.registerCommand('analyticsdx.telemetry.send', sendTelemetryCommand)

--- a/extensions/analyticsdx-vscode-core/src/messages/i18n.ts
+++ b/extensions/analyticsdx-vscode-core/src/messages/i18n.ts
@@ -45,8 +45,13 @@ export const messages = Object.freeze({
 
   // commands/updateTemplate.ts
   update_template_cmd_message: 'Updating analytics template from associated app...',
-  update_template_cmd_no_apps_message: 'No templates associated to an app available in org.',
+  update_template_cmd_no_templates_message: 'No templates associated to an app available in org.',
   update_template_cmd_placeholder_message: 'Select an analytics template to update from its app...',
+  update_template_from_app_cmd_message: 'Updating analytics template from app...',
+  update_template_from_app_cmd_no_templates_message: 'No templates available in org.',
+  update_template_from_app_cmd_placeholder_message: 'Select an analytics template to update...',
+  update_template_from_app_cmd_no_apps_message: 'No apps created from the template available in the org.',
+  update_template_from_app_cmd_current_app_details: 'Current Associated App',
 
   // commands/gatherers/appGatherer.ts
   app_gatherer_def_no_apps_message: 'No matching apps available in org.',

--- a/extensions/analyticsdx-vscode-core/src/util/sfdx.ts
+++ b/extensions/analyticsdx-vscode-core/src/util/sfdx.ts
@@ -27,8 +27,9 @@ import { getRootWorkspacePath } from './rootWorkspace';
 const pluginName = '@salesforce/analytics';
 
 // The minumum version of the @salesforce/analytics plugins our extensions require for everything to work right.
-// The sfdx call in createApp() needs 0.19.0
-const minAdxPluginVersion = '0.19.0';
+// The -e arg for analytics:template:list is new in 0.22.0 (it also requires Winter '21 v50.0 release to actually
+// include the embeddedapp templates in the output, but it at least doesn't fail on Summer '20 v49.0)
+const minAdxPluginVersion = '0.22.0';
 
 export async function isSfdxInstalled(): Promise<boolean> {
   try {

--- a/packages/analyticsdx-test-utils-vscode/src/testrunner.ts
+++ b/packages/analyticsdx-test-utils-vscode/src/testrunner.ts
@@ -107,7 +107,9 @@ function run(testsRoot: any, clb: any): any {
           });
         })
         .on('fail', (test: any, err: any): void => {
-          console.log(`Failure in test '${test}': ${err}`);
+          const testName =
+            (test.parent && test.parent.fullTitle ? test.parent.fullTitle() + ' ' : '') + (test.title || test);
+          console.log(`Failure in test '${testName}': ${err}`);
           failureCount++;
         })
         .on('end', (): void => {

--- a/tslint.json
+++ b/tslint.json
@@ -1,27 +1,16 @@
 {
   "extends": "@salesforce/dev-config/tslint",
-  "rulesDirectory": [
-    "tslint-no-focused-test"
-  ],
+  "rulesDirectory": ["tslint-no-focused-test"],
   "rules": {
     "no-focused-test": true,
     "no-reserved-keywords": false,
     "no-any": false,
-    "quotemark": [
-      true,
-      "single",
-      "avoid-escape"
-    ],
+    "quotemark": [true, "single", "avoid-escape"],
     "member-ordering": false,
     "no-string-based-set-timeout": false,
-    "semicolon": [
-      true,
-      "always",
-      "ignore-bound-class-methods"
-    ],
+    "semicolon": [true, "always", "ignore-bound-class-methods"],
     "no-shadowed-variable": false,
-    "comment-format": [
-      true
-    ]
+    "no-unnecessary-initializer": false,
+    "comment-format": [true]
   }
 }


### PR DESCRIPTION
* Support embeddedapp templates in various commands (Delete Template and Update Template, skip them on Create App From Template)
* Add a Update Template From App:
  * show a list of apps that were created from that template to pick from=
  * if the template currently has a source app, show that first in the list so it's the default if they just hit enter