### PR TITLE
Switch to /analytics urls for opening Analytics Studio

### DIFF
--- a/extensions/analyticsdx-vscode-core/package.json
+++ b/extensions/analyticsdx-vscode-core/package.json
@@ -47,6 +47,7 @@
     "mocha": "7.0.1",
     "mocha-junit-reporter": "^1.13.0",
     "mocha-multi-reporters": "^1.1.4",
+    "mock-spawn": "0.2.6",
     "nyc": "^15.0.0",
     "shx": "0.3.2",
     "sinon": "8.1.1",
@@ -177,8 +178,8 @@
         "analyticsdx-vscode-core.studio.path": {
           "type": "string",
           "description": "%config_studio_path_desc%",
-          "default": "/wave/wave.app",
-          "pattern": "^[^\\s].*",
+          "default": "/analytics/",
+          "pattern": "^[^\\s#][^#]*$",
           "patternErrorMessage": "%config_studio_path_error%"
         },
         "analyticsdx-vscode-core.CLI.checkForPlugin": {

--- a/extensions/analyticsdx-vscode-core/package.nls.json
+++ b/extensions/analyticsdx-vscode-core/package.nls.json
@@ -1,6 +1,6 @@
 {
   "config_studio_path_desc": "Specify the relative uri path to use when opening Analytics Studio",
-  "config_studio_path_error": "Value must not be empty and must not start with whitespace.",
+  "config_studio_path_error": "Value must not be empty, start with whitespace, nor use a # fragment.",
   "config_check_sfdx_plugin_desc": "Check for the Analytics Salesforce CLI plugin on startup",
 
   "analyticsdx_app_create_blank_label": "SFDX: Create Blank Analytics App",

--- a/extensions/analyticsdx-vscode-core/src/commands/commands.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/commands.ts
@@ -47,7 +47,7 @@ const emptyPreChecker: PreconditionChecker = {
 // from there, just changing it to use a CommandOutput and return a Promise<string>
 // with the stdout -- this could pretty easily be added as an option to the code in
 // core
-export class SfdxCommandletExecutorWithOutput<T> extends SfdxCommandletExecutor<T> {
+export abstract class SfdxCommandletExecutorWithOutput<T> extends SfdxCommandletExecutor<T> {
   public execute(response: ContinueResponse<T>): Promise<string> {
     const startTime = process.hrtime();
     const cancellationTokenSource = new vscode.CancellationTokenSource();
@@ -62,6 +62,8 @@ export class SfdxCommandletExecutorWithOutput<T> extends SfdxCommandletExecutor<
     this.attachExecution(execution, cancellationTokenSource, cancellationToken);
     return new CommandOutput().getCmdResult(execution);
   }
+
+  public abstract build(data: T): Command;
 }
 
 export class EmptyPostChecker implements PostconditionChecker<any> {

--- a/extensions/analyticsdx-vscode-core/src/commands/openStudio.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/openStudio.ts
@@ -12,7 +12,6 @@ import {
   emptyParametersGatherer,
   SfdxCommandBuilder,
   SfdxCommandlet,
-  SfdxCommandletExecutor,
   SfdxCommandletExecutorWithOutput,
   sfdxWorkspaceChecker
 } from './commands';
@@ -23,30 +22,40 @@ export function baseStudioPath() {
     vscode.workspace
       .getConfiguration()
       .get<string>('analyticsdx-vscode-core.studio.path')
-      ?.trimLeft() || '/wave/wave.app'
+      ?.trimLeft() || '/analytics/'
   );
 }
 
 // REVIEWME: just get the url from sfdx and open in a vscode WebViewPanel?
 
-// This will have sfdx print the url, which this will read and use with vscode.env.openExternal().
-// This is for when running in web mode (Visual Studio Online).
-// Note: I can't seem to get Studio urls that use a # to work when going through sfdx -> Uri.parse() ->
-// openExternal() -> frontdoor.jsp -> retURL, something in there seems to double-encode the query params in a way
-// which the server then doesn't double-decode correctly, and it gets a 404 from the server since the # in the
-// url ends up as a literal %23 instead of the original #.
-// Since the Studio UI is going to move to /-based url navigation in a near future release (where /'s do seem to work
-// fine), we can update things to always use openExternal() in the future, and for now just not support our #-url-based
-// commands in web mode.
-class OpenExternalStudioExecutor<T> extends SfdxCommandletExecutorWithOutput<T> {
-  constructor(private readonly logName = 'analytics_open_studio') {
+// This will have sfdx print the url, which this will read and use with vscode.env.openExternal() so that
+// it works in Code Builder (and Github Codespaces).
+
+class OpenStudioExecutor<T> extends SfdxCommandletExecutorWithOutput<T> {
+  constructor(
+    // this value should not start with /
+    private readonly routegen: string | ((data: T) => string),
+    private readonly logName = 'analytics_open_studio'
+  ) {
     super();
   }
 
   public build(data: T) {
     let path = baseStudioPath();
-    // if they put a #hash in the path in the config, chop that off since it won't work anyways
-    path = path.replace(/#.*$/, '');
+    const route = typeof this.routegen === 'string' ? this.routegen : this.routegen(data);
+    if (path.indexOf('%s') >= 0) {
+      path = path.replace('%s', route);
+    } else {
+      if (!path.endsWith('/')) {
+        path += '/';
+      }
+      path += route;
+    }
+    // #'s in the url don't work when going through sfdx -> Uri.parse() -> openExternal() -> frontdoor.jsp -> retURL,
+    // something in there seems to double-encode the query params in a way which the server then doesn't double-decode
+    // correctly, and it gets a 404 from the server since the # in the url ends up as a literal %23 instead of the
+    // original #, so just get rid of that for now
+    path.replace(/#.*$/, '');
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('open_studio_cmd_message'))
       .withArg('force:org:open')
@@ -65,43 +74,17 @@ class OpenExternalStudioExecutor<T> extends SfdxCommandletExecutorWithOutput<T> 
       if (json?.status === 0 && json?.result?.url) {
         const uri = vscode.Uri.parse(json.result.url as string);
         vscode.env.openExternal(uri);
+        return uri.toString();
       }
     }
-    return jsonStr;
-  }
-}
-
-// This has sfdx open the url, which only works in desktop mode
-class OpenStudioExecutor<T> extends SfdxCommandletExecutor<T> {
-  constructor(
-    private readonly logName = 'analytics_open_studio',
-    private readonly hashgen?: (t: T) => string | undefined
-  ) {
-    super();
-  }
-
-  public build(data: T) {
-    let path = baseStudioPath();
-    const hash = this.hashgen?.(data);
-    if (hash) {
-      // if they put a #hash in the path in the config, chop that off to put this hash on
-      path = path.replace(/#.*$/, '');
-      path += '#' + hash;
-    }
-    return new SfdxCommandBuilder()
-      .withDescription(nls.localize('open_studio_cmd_message'))
-      .withArg('force:org:open')
-      .withArg('-p')
-      .withArg(path)
-      .withLogName(this.logName)
-      .build();
+    throw new Error(nls.localize('open_studio_cmd_error'));
   }
 }
 
 const openStudioCommandlet = new SfdxCommandlet(
   sfdxWorkspaceChecker,
   emptyParametersGatherer,
-  vscode.env.uiKind === vscode.UIKind.Web ? new OpenExternalStudioExecutor() : new OpenStudioExecutor()
+  new OpenStudioExecutor('home')
 );
 
 export async function openStudio() {
@@ -111,26 +94,22 @@ export async function openStudio() {
 const openDataManagerCommandlet = new SfdxCommandlet(
   sfdxWorkspaceChecker,
   emptyParametersGatherer,
-  new OpenStudioExecutor('analytics_open_dataManager', () => 'dataManager')
+  new OpenStudioExecutor('dataManager', 'analytics_open_dataManager')
 );
 
 export async function openDataManager() {
-  if (vscode.env.uiKind !== vscode.UIKind.Web) {
-    await openDataManagerCommandlet.run();
-  }
+  await openDataManagerCommandlet.run();
 }
 
 const openAppCommandlet = new SfdxCommandlet(
   sfdxWorkspaceChecker,
   new AppGatherer(),
   new OpenStudioExecutor<AppMetadata>(
-    'analytics_open_app_in_studio',
-    app => 'application/' + encodeURIComponent(app.folderid) + '/edit'
+    app => 'application/' + encodeURIComponent(app.folderid) + '/edit',
+    'analytics_open_app_in_studio'
   )
 );
 
 export async function openAppInStudio() {
-  if (vscode.env.uiKind !== vscode.UIKind.Web) {
-    await openAppCommandlet.run();
-  }
+  await openAppCommandlet.run();
 }

--- a/extensions/analyticsdx-vscode-core/src/messages/i18n.ts
+++ b/extensions/analyticsdx-vscode-core/src/messages/i18n.ts
@@ -42,6 +42,7 @@ export const messages = Object.freeze({
 
   // commands/openStudio.js
   open_studio_cmd_message: 'Opening Analytics Studio...',
+  open_studio_cmd_error: 'Unable to determine org url',
 
   // commands/updateTemplate.ts
   update_template_cmd_message: 'Updating analytics template from associated app...',

--- a/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/commands.test.ts
+++ b/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/commands.test.ts
@@ -6,12 +6,51 @@
  */
 
 import { expect } from 'chai';
-import { ContinueResponse, EmptyPostChecker } from '../../../src/commands/commands';
+import {
+  Command,
+  ContinueResponse,
+  EmptyPostChecker,
+  SfdxCommandBuilder,
+  SfdxCommandletExecutorWithOutput
+} from '../../../src/commands/commands';
+import childProcess = require('child_process');
+
+class TestExecutorWithOutput extends SfdxCommandletExecutorWithOutput<string> {
+  public build(data: string): Command {
+    return new SfdxCommandBuilder().withArg(data).build();
+  }
+}
 
 describe('Command Utilities', () => {
-  describe.skip('SfdxCommandletExecutorWithOutput', async () => {
-    it.skip('Returns command output', () => {
-      // TODO: implement
+  describe('SfdxCommandletExecutorWithOutput', async () => {
+    const mockSpawnLib = require('mock-spawn');
+    let origSpawn: any;
+    let mockSpawn: any;
+    beforeEach(() => {
+      origSpawn = childProcess.spawn;
+      mockSpawn = mockSpawnLib();
+      childProcess.spawn = mockSpawn;
+    });
+
+    afterEach(() => {
+      childProcess.spawn = origSpawn;
+    });
+
+    it('Returns command output', async () => {
+      const expectedOutput = JSON.stringify(
+        {
+          status: 0,
+          result: {
+            name: 'value'
+          }
+        },
+        undefined,
+        2
+      );
+      mockSpawn.setDefault(mockSpawn.simple(0, expectedOutput));
+      const cmd = new TestExecutorWithOutput();
+      const output = await cmd.execute({ type: 'CONTINUE', data: 'inputvalue' });
+      expect(output).to.equal(expectedOutput);
     });
   });
 

--- a/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/openStudio.test.ts
+++ b/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/openStudio.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import childProcess = require('child_process');
+import { openAppInStudio, openDataManager, openStudio, SfdxCommandBuilder } from '../../../src/commands';
+import { AppGatherer } from '../../../src/commands/gatherers/appGatherer';
+
+describe('openStudio.ts', () => {
+  const mockSpawnLib = require('mock-spawn');
+  let origSpawn: any;
+  let mockSpawn: any;
+
+  let sandbox: sinon.SinonSandbox;
+  let withArgSpy: sinon.SinonSpy<[string], SfdxCommandBuilder>;
+  let openExternal: sinon.SinonStub<any>;
+
+  // Note: replace with Array.flat() once we're on ES6
+  function flatten<T>(array: T[][]): T[] {
+    return ([] as T[]).concat(...array);
+  }
+
+  beforeEach(() => {
+    origSpawn = childProcess.spawn;
+    mockSpawn = mockSpawnLib();
+    childProcess.spawn = mockSpawn;
+
+    sandbox = sinon.createSandbox();
+    withArgSpy = sandbox.spy(SfdxCommandBuilder.prototype, 'withArg');
+    openExternal = sandbox.stub(vscode.env, 'openExternal');
+    openExternal.returns(Promise.resolve(true));
+  });
+
+  afterEach(() => {
+    childProcess.spawn = origSpawn;
+    sandbox.restore();
+  });
+
+  it('openStudio() parses sfdx response successfully', async () => {
+    const expectedUrl = 'https://mydomain.salesforce.com/secur/frontdoor.jsp?sid=sid&retURL=analytics%2Fhome';
+    mockSpawn.setDefault(
+      mockSpawn.simple(
+        0,
+        JSON.stringify(
+          {
+            status: 0,
+            result: {
+              url: expectedUrl
+            }
+          },
+          undefined,
+          2
+        )
+      )
+    );
+
+    await openStudio();
+    // make sure sfdx got the right -p arg
+    sinon.assert.called(withArgSpy);
+    expect(flatten(withArgSpy.args), 'sfdx args').to.include.members(['-p', '/analytics/home']);
+
+    // and that it called vscode.env.openExternal with the url from the output
+    sinon.assert.calledOnce(openExternal);
+    // vscode.Uri doesn't implement equals() so have to do string compare
+    expect(openExternal.firstCall.args[0].toString(), 'uri').to.equal(vscode.Uri.parse(expectedUrl).toString());
+  });
+
+  it('openDataManager() sends correct route', async () => {
+    mockSpawn.setDefault(
+      mockSpawn.simple(
+        0,
+        JSON.stringify(
+          {
+            status: 0,
+            result: {
+              url: 'https://mydomain.salesforce.com/secur/frontdoor.jsp?sid=sid&retURL=analytics%2FdataManager'
+            }
+          },
+          undefined,
+          2
+        )
+      )
+    );
+    await openDataManager();
+    // make sure sfdx got the right -p arg
+    sinon.assert.called(withArgSpy);
+    expect(flatten(withArgSpy.args), 'sfdx args').to.include.members(['-p', '/analytics/dataManager']);
+  });
+
+  it('openAppInStudio() sends correct route', async () => {
+    mockSpawn.setDefault(
+      mockSpawn.simple(
+        0,
+        JSON.stringify(
+          {
+            status: 0,
+            result: {
+              url:
+                'https://mydomain.salesforce.com/secur/frontdoor.jsp?sid=sid&retURL=analytics%2Fapplication%2Fid%2Fedit'
+            }
+          },
+          undefined,
+          2
+        )
+      )
+    );
+
+    const gatherStub = sandbox.stub(AppGatherer.prototype, 'gather');
+    gatherStub.returns(
+      Promise.resolve({
+        type: 'CONTINUE',
+        data: {
+          name: 'app',
+          label: 'app',
+          folderid: 'id',
+          status: 'status'
+        }
+      })
+    );
+    await openAppInStudio();
+    // make sure sfdx got the right -p arg
+    sinon.assert.called(withArgSpy);
+    expect(flatten(withArgSpy.args), 'sfdx args').to.include.members(['-p', '/analytics/application/id/edit']);
+  });
+
+  it('openAppInStudio() no-ops on cancel', async () => {
+    const gatherStub = sandbox.stub(AppGatherer.prototype, 'gather');
+    gatherStub.returns(
+      Promise.resolve({
+        type: 'CANCEL'
+      })
+    );
+    await openAppInStudio();
+    // make sure an sfdx command wasn't built
+    sinon.assert.notCalled(withArgSpy);
+    // and no call to open a url
+    sinon.assert.notCalled(openExternal);
+  });
+});


### PR DESCRIPTION
Now that Winter '21 (228) is deployed everywhere, that's the new url path.
This also avoids the issues with #-based urls and vscode.env.openExternal() in
Code Builder/Github Codespaces.

Also, adds tests for the open studio commands, by mocking out the sfdx
execution.