### PR TITLE
Show loading and no items message in pickers

### DIFF
--- a/extensions/analyticsdx-vscode-core/src/commands/gatherers/appGatherer.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/gatherers/appGatherer.ts
@@ -8,11 +8,11 @@
 import * as vscode from 'vscode';
 import { ICONS } from '../../constants';
 import { nls } from '../../messages';
+import { showQuickPick } from '../../util/quickpick';
 import {
   CancelResponse,
   ContinueResponse,
   emptyParametersGatherer,
-  notificationService,
   ParametersGatherer,
   SfdxCommandBuilder,
   SfdxCommandletExecutorWithOutput,
@@ -91,12 +91,9 @@ export class AppGatherer implements ParametersGatherer<AppMetadata> {
   }
 
   public async gather(): Promise<CancelResponse | ContinueResponse<AppMetadata>> {
-    const items = await this.loadQuickPickItems();
-    if (items.length <= 0) {
-      notificationService.showInformationMessage(this.noAppsMesg);
-      return { type: 'CANCEL' };
-    }
-    const selection = await vscode.window.showQuickPick(items, {
+    const selection = await showQuickPick(this.loadQuickPickItems(), {
+      noItemsMesg: this.noAppsMesg,
+      loadingMesg: this.fetchMesg,
       matchOnDescription: true,
       placeHolder: this.placeholderMesg
     });

--- a/extensions/analyticsdx-vscode-core/src/commands/gatherers/templateGatherer.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/gatherers/templateGatherer.ts
@@ -7,11 +7,11 @@
 import * as vscode from 'vscode';
 import { ICONS } from '../../constants';
 import { nls } from '../../messages';
+import { showQuickPick } from '../../util/quickpick';
 import {
   CancelResponse,
   ContinueResponse,
   emptyParametersGatherer,
-  notificationService,
   ParametersGatherer,
   SfdxCommandBuilder,
   SfdxCommandletExecutorWithOutput,
@@ -125,12 +125,9 @@ export class TemplateGatherer implements ParametersGatherer<TemplateMetadata> {
   }
 
   public async gather(): Promise<CancelResponse | ContinueResponse<TemplateMetadata>> {
-    const items = await this.loadQuickPickItems();
-    if (items.length <= 0) {
-      notificationService.showInformationMessage(this.noTemplatesMesg);
-      return { type: 'CANCEL' };
-    }
-    const selection = await vscode.window.showQuickPick(items, {
+    const selection = await showQuickPick(this.loadQuickPickItems(), {
+      noItemsMesg: this.noTemplatesMesg,
+      loadingMesg: this.fetchMesg,
       matchOnDescription: true,
       placeHolder: this.placeholderMesg
     });

--- a/extensions/analyticsdx-vscode-core/src/commands/updateTemplate.ts
+++ b/extensions/analyticsdx-vscode-core/src/commands/updateTemplate.ts
@@ -4,12 +4,11 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import * as vscode from 'vscode';
 import { nls } from '../messages';
+import { showQuickPick } from '../util/quickpick';
 import {
   CancelResponse,
   ContinueResponse,
-  notificationService,
   SfdxCommandBuilder,
   SfdxCommandlet,
   SfdxCommandletExecutor,
@@ -76,18 +75,16 @@ class TemplateAndFolderGatherer extends TemplateGatherer {
         matchingAppItems.push(item);
       }
     }
-    if (!currentAppItem && matchingAppItems.length <= 0) {
-      // TODO: add an option to create a new app from the template and use that as the source app
-      notificationService.showInformationMessage(nls.localize('update_template_from_app_cmd_no_apps_message'));
-      return { type: 'CANCEL' };
-    }
+
+    // TODO: add an option to create a new app from the template and use that as the source app
 
     // put the template's current app first in the list so it's the default selection
     if (currentAppItem) {
       currentAppItem.detail = nls.localize('update_template_from_app_cmd_current_app_details');
       matchingAppItems.unshift(currentAppItem);
     }
-    const appResponse = await vscode.window.showQuickPick(matchingAppItems, {
+    const appResponse = await showQuickPick(matchingAppItems, {
+      noItemsMesg: nls.localize('update_template_from_app_cmd_no_apps_message'),
       matchOnDescription: true,
       placeHolder: nls.localize('app_gatherer_def_placeholder_message'),
       matchOnDetail: true

--- a/extensions/analyticsdx-vscode-core/src/util/quickpick.ts
+++ b/extensions/analyticsdx-vscode-core/src/util/quickpick.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as vscode from 'vscode';
+import { ICONS } from '../constants';
+
+class NoItemsQuickPickItem implements vscode.QuickPickItem {
+  public readonly label: string;
+  constructor(icon: string, mesg: string) {
+    this.label = (icon ? `$(${icon}) ` : '') + ICONS.escape(mesg);
+  }
+
+  // have it always show, no matter what's in the filter text box
+  get alwaysShow() {
+    return true;
+  }
+}
+
+/** A single-item showQuickPick that supports showing an inline progress bar, and handles the case where no items
+ * are available by being non-selectable.
+ * @param itemsOrPromise the items or a promise of the items (loading bar only shown for a promise)
+ * @param options regular quick pick options (canPickMany ignored), plus additional options
+ * @param options.noItemsMesg the message to show when there are no items
+ * @param options.loadingMesg optional message to show when loading the items (only valid when itemsOrPromise is a
+ *        promise)
+ * @param options.loadingErrorMesg optional message or message generator function for when the items fails to load
+ *        (only valid when itemsOrPromise is a promise, defaults to noItemsMesg)
+ * @returns the selected item, or undefined on cancel or no items or error loading
+ */
+export async function showQuickPick<T extends vscode.QuickPickItem>(
+  itemsOrPromise: T[] | Promise<T[]>,
+  options: vscode.QuickPickOptions & {
+    noItemsMesg: string;
+    loadingMesg?: string;
+    loadingErrorMesg?: string | ((e: Error | any) => string);
+  }
+): Promise<T | undefined> {
+  const qp = vscode.window.createQuickPick<T | NoItemsQuickPickItem>();
+  qp.matchOnDescription = !!options.matchOnDescription;
+  qp.matchOnDetail = !!options.matchOnDetail;
+  qp.placeholder = options.placeHolder;
+  qp.ignoreFocusOut = !!options.ignoreFocusOut;
+  qp.canSelectMany = false;
+  qp.enabled = false;
+  if (itemsOrPromise instanceof Promise && options.loadingMesg) {
+    qp.items = [new NoItemsQuickPickItem('loading~spin', options.loadingMesg)];
+  }
+  qp.show();
+  try {
+    if (itemsOrPromise instanceof Promise) {
+      qp.busy = true;
+    }
+    try {
+      const items = await itemsOrPromise;
+      if (items && items.length > 0) {
+        // only enable the QuickPick if there are items
+        qp.enabled = true;
+        qp.items = items;
+      } else {
+        qp.items = [new NoItemsQuickPickItem('issues', options.noItemsMesg)];
+      }
+    } catch (e) {
+      const mesg =
+        (typeof options.loadingErrorMesg === 'string' && options.loadingErrorMesg) ||
+        (typeof options.loadingErrorMesg === 'function' && options.loadingErrorMesg(e));
+      qp.items = [new NoItemsQuickPickItem('error', mesg || options.noItemsMesg)];
+    }
+    qp.busy = false;
+    // wait until something's either selected or they close it
+    const result = await Promise.race([
+      new Promise<T | NoItemsQuickPickItem>(resolve => qp.onDidAccept(() => resolve(qp.selectedItems[0]))),
+      new Promise<undefined>(resolve => qp.onDidHide(() => resolve(undefined)))
+    ]);
+    return !result || result instanceof NoItemsQuickPickItem ? undefined : result;
+  } finally {
+    qp.dispose();
+  }
+}


### PR DESCRIPTION
Now, for the commands that show a list of apps or templates, it will show the empty picker right away with the loading bar and a loading message. Once the items load, you can pick one, or, if there are none available, it will show a message in the picker (instead of hiding the picker and showing a notification popup in the bottom corner, which was kind of jarring).