### PR TITLE
Add refresh api hook to dashboard lwcs

### DIFF
--- a/extensions/analyticsdx-vscode-core/package.json
+++ b/extensions/analyticsdx-vscode-core/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "file:../../lib/salesforcedx-utils-vscode.tgz",
-    "@salesforce/templates": "52.4.0",
+    "@salesforce/templates": "54.3.0",
     "glob": "7.2.0",
     "semver": "7.3.5",
     "tmp": "0.2.1",

--- a/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/createDashboardLWC.test.ts
+++ b/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/createDashboardLWC.test.ts
@@ -36,6 +36,7 @@ async function verifyLWC(lwcDir: vscode.Uri, lwcName: string, hasStep: boolean) 
   );
   expect(text, jsFileName).to.match(/@api\s+getState;/);
   expect(text, jsFileName).to.match(/@api\s+setState;/);
+  expect(text, jsFileName).to.match(/@api\s+refresh;/);
   if (hasStep) {
     expect(text, jsFileName).to.match(/@api\s+results;/);
     expect(text, jsFileName).to.match(/@api\s+metadata;/);


### PR DESCRIPTION
This brings in forcedotcom/salesforcedx-templates#469 from [@salesforce/templates 54.3.0](https://www.npmjs.com/package/@salesforce/templates) to add:
```
@api refresh;
```
to LWCs created from the **SFDX: Create Analytics Dashboard LWC** command.
