### PR TITLE
More data template validations

### DIFF
--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateLinter/ui.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateLinter/ui.test.ts
@@ -232,7 +232,9 @@ describe('TemplateLinterManager lints ui.json', () => {
         const diagnostic = diagnostics[i];
         expect(diagnostic, `diagnostics[${i}]`).to.be.not.undefined;
         expect(diagnostic.message, `diagnostics[${i}].message`).to.equal(
-          `${type} variable '${type}Var' is not supported in ui pages`
+          type === 'DatasetAnyFieldType'
+            ? `${type} variable '${type}Var' is only supported in ui pages in data templates`
+            : `${type} variable '${type}Var' is not supported in ui pages`
         );
         expect(diagnostic.code, `diagnostics[${i}].code`).to.equal(ERRORS.UI_PAGE_UNSUPPORTED_VARIABLE);
         expect(jsonpathFrom(diagnostic), `diagnostics[${i}].jsonpath`).to.equal(`pages[${j}].variables[${k}].name`);

--- a/packages/analyticsdx-template-lint/src/constants.ts
+++ b/packages/analyticsdx-template-lint/src/constants.ts
@@ -157,6 +157,8 @@ export const ERRORS = Object.freeze({
   UI_PAGE_UNKNOWN_VARIABLE: 'ui-3',
   /** Unsupported variable type in non-vfPage ui page */
   UI_PAGE_UNSUPPORTED_VARIABLE: 'ui-4',
+  /** vfPage is unsupported for the template type */
+  UI_PAGE_VFPAGE_UNSUPPORTED: 'ui-5',
 
   /** Duplicate constant in rules file(s) */
   RULES_DUPLICATE_CONSTANT: 'rules-1',

--- a/packages/analyticsdx-template-lint/src/linter.ts
+++ b/packages/analyticsdx-template-lint/src/linter.ts
@@ -1020,6 +1020,7 @@ export abstract class TemplateLinter<
             .filter(isValidVariableName)
             [Symbol.iterator]()
       });
+      const [templateType] = findJsonPrimitiveAttributeValue(templateInfo, 'templateType');
       // find all the variable objects
       matchJsonNodesAtPattern(pages.children, ['variables', '*', 'name']).forEach(nameNode => {
         if (nameNode && nameNode.type === 'string' && nameNode.value) {
@@ -1037,10 +1038,20 @@ export abstract class TemplateLinter<
             this.addDiagnostic(uiDoc, mesg, ERRORS.UI_PAGE_UNKNOWN_VARIABLE, nameNode, { args });
           } else {
             const type = variableTypes[name];
-            if (type === 'ObjectType' || type === 'DateTimeType' || type === 'DatasetAnyFieldType') {
+            if (type === 'ObjectType' || type === 'DateTimeType') {
               this.addDiagnostic(
                 uiDoc,
                 `${type} variable '${name}' is not supported in ui pages`,
+                ERRORS.UI_PAGE_UNSUPPORTED_VARIABLE,
+                nameNode
+              );
+            } else if (
+              type === 'DatasetAnyFieldType' &&
+              !(typeof templateType === 'string' && templateType.toLowerCase() === 'data')
+            ) {
+              this.addDiagnostic(
+                uiDoc,
+                `${type} variable '${name}' is only supported in ui pages in data templates`,
                 ERRORS.UI_PAGE_UNSUPPORTED_VARIABLE,
                 nameNode
               );

--- a/packages/analyticsdx-template-lint/test/unit/linter.test.ts
+++ b/packages/analyticsdx-template-lint/test/unit/linter.test.ts
@@ -142,11 +142,18 @@ describe('TemplateLinter', () => {
 
   describe('ui.json', () => {
     [
-      { templateType: 'data', numErrors: 0 },
-      { templateType: 'app', numErrors: 1 }
-    ].forEach(({ templateType, numErrors }) => {
-      it(`validates DatasetAnyFieldType for ${templateType} template`, async () => {
-        const dir = 'datasetAnyFieldType';
+      { templateType: 'data', numErrors: 0, type: 'DatasetAnyFieldType', isArray: false },
+      { templateType: 'data', numErrors: 0, type: 'DatasetAnyFieldType', isArray: true },
+      { templateType: 'app', numErrors: 1, type: 'DatasetAnyFieldType', isArray: false },
+      { templateType: 'app', numErrors: 1, type: 'DatasetAnyFieldType', isArray: true },
+      { templateType: 'app', numErrors: 1, type: 'ObjectType', isArray: false },
+      { templateType: 'app', numErrors: 1, type: 'ObjectType', isArray: true },
+      { templateType: 'app', numErrors: 1, type: 'DateTimeType', isArray: false },
+      { templateType: 'app', numErrors: 1, type: 'DateTimeType', isArray: true }
+    ].forEach(({ templateType, numErrors, type, isArray }) => {
+      it(`validates ${type}${isArray ? '[]' : ''} variable for ${templateType} template`, async () => {
+        const dir = type;
+        const variableType = isArray ? { type: 'ArrayType', itemsType: { type } } : { type };
         linter = new TestLinter(
           dir,
           {
@@ -155,13 +162,13 @@ describe('TemplateLinter', () => {
             variableDefinition: 'variables.json'
           },
           new StringDocument(path.join(dir, 'variables.json'), {
-            anyFieldVar: { variableType: { type: 'DatasetAnyFieldType' } }
+            var: { variableType }
           }),
           new StringDocument(path.join(dir, 'ui.json'), {
             pages: [
               {
                 title: 'title',
-                variables: [{ name: 'anyFieldVar' }]
+                variables: [{ name: 'var' }]
               }
             ]
           })

--- a/packages/analyticsdx-template-lint/test/unit/linter.test.ts
+++ b/packages/analyticsdx-template-lint/test/unit/linter.test.ts
@@ -186,5 +186,37 @@ describe('TemplateLinter', () => {
         }
       });
     });
+
+    it('validates vfPages in data templates', async () => {
+      const dir = 'vfPageInDataTemplate';
+      linter = new TestLinter(
+        dir,
+        {
+          templateType: 'data',
+          uiDefinition: 'ui.json',
+          variableDefinition: 'variables.json'
+        },
+        new StringDocument(path.join(dir, 'ui.json'), {
+          pages: [
+            {
+              title: 'title',
+              vfPage: {
+                name: 'name',
+                namespace: 'ns'
+              }
+            }
+          ]
+        })
+      );
+      await linter.lint();
+      const diagnostics = getDiagnosticsForPath(linter.diagnostics, path.join(linter.dir, 'ui.json'))?.filter(
+        d => d.code === ERRORS.UI_PAGE_VFPAGE_UNSUPPORTED
+      );
+      if (diagnostics?.length !== 1) {
+        expect.fail(
+          `Expected 1 ${ERRORS.UI_PAGE_VFPAGE_UNSUPPORTED} diagnostics, got: ` + stringifyDiagnostics(diagnostics)
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
* Allow `DatasetAnyFieldType` variables in ui.json for `data` templates
* Warn on `vfPage` on ui.json pages for `data` templates
* Warn on `ArrayType` of unsupported variable types
