### PR TITLE
Data template code completion and bug fix

### DIFF
--- a/extensions/analyticsdx-vscode-templates/src/templateInfo/actions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateInfo/actions.ts
@@ -123,9 +123,8 @@ export class CreateFolderShareCodeActionProvider implements vscode.CodeActionPro
           jsonStringifyWithOptions({ shares: [DEFAULT_SHARE_JSON] }, formattingOptions)
         );
       } else {
-        // -1 means add to the end of the "shares" array (which should be the first item since it should be missing or
-        // empty)
-        const edits = jsonModify(folderText, ['shares', -1], DEFAULT_SHARE_JSON, { formattingOptions });
+        // shares should be missing, null, empty, or not-an-array so just set it
+        const edits = jsonModify(folderText, ['shares'], [DEFAULT_SHARE_JSON], { formattingOptions });
         // no actual edits, so no need for a quick fix
         if (edits.length <= 0) {
           return undefined;

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/schemas/templateInfoSchema.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/schemas/templateInfoSchema.test.ts
@@ -278,7 +278,7 @@ describe('template-info-schema.json hookup', () => {
 
     // make a test for each of these fields to make sure it has the expected completion items
     [
-      { jsonpath: ['templateType'] as JSONPath, completions: ['"app"', '"dashboard"', '"embeddedapp"'] },
+      { jsonpath: ['templateType'] as JSONPath, completions: ['"app"', '"dashboard"', '"data"', '"embeddedapp"'] },
       { jsonpath: ['variableDefinition'], completions: ['""'] },
       { jsonpath: ['uiDefinition'], completions: ['""'] },
       { jsonpath: ['ruleDefinition'], completions: ['""'] },

--- a/packages/analyticsdx-template-lint/src/schemas/template-info-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/template-info-schema.json
@@ -44,17 +44,18 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": ["app", "dashboard", "embeddedapp"],
+          "enum": ["app", "dashboard", "data", "embeddedapp"],
           "enumDescriptions": [
             "Specify that the template creates an app.",
             "Specify that the template creates a dashboard.",
+            "Specify that the template creates a data app.",
             "Specify that the template creates an embedded app."
           ]
         },
         {
           "type": "string",
           "$comment": "These are also valid in the server, but we shouldn't prompt users for them. Also, json-schema doesn't support sending in a case-sensitive flag nor doing a (?i) group.",
-          "pattern": "^(lens|Lens|TemporaryApp|temporaryApp|temporaryapp|Data|data)$"
+          "pattern": "^(lens|Lens|TemporaryApp|temporaryApp|temporaryapp)$"
         },
         {
           "type": "null"


### PR DESCRIPTION
### What does this PR do?
- Adds `data` to `templateType` completions
- Fixes unrelated bug on folder.json quickfix when `shares` field is `null`.