### PR TITLE
Add `stateChangedCallback()` to dashboard lwcs

### DIFF
--- a/extensions/analyticsdx-vscode-core/package.json
+++ b/extensions/analyticsdx-vscode-core/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "file:../../lib/salesforcedx-utils-vscode.tgz",
-    "@salesforce/templates": "54.3.0",
+    "@salesforce/templates": "54.7.0",
     "glob": "7.2.0",
     "semver": "7.3.5",
     "tmp": "0.2.1",

--- a/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/createDashboardLWC.test.ts
+++ b/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/createDashboardLWC.test.ts
@@ -37,6 +37,7 @@ async function verifyLWC(lwcDir: vscode.Uri, lwcName: string, hasStep: boolean) 
   expect(text, jsFileName).to.match(/@api\s+getState;/);
   expect(text, jsFileName).to.match(/@api\s+setState;/);
   expect(text, jsFileName).to.match(/@api\s+refresh;/);
+  expect(text, jsFileName).to.match(/@api\s+stateChangedCallback([^\s]+,\s*[^\s]+)\s*{.*}/);
   if (hasStep) {
     expect(text, jsFileName).to.match(/@api\s+results;/);
     expect(text, jsFileName).to.match(/@api\s+metadata;/);


### PR DESCRIPTION
### What does this PR do?
Brings in 54.7.0 of [salesforcedx-templates](https://github.com/forcedotcom/salesforcedx-templates), which add the `stateChangedCallback()` to generated analytics dashboard LWCs.

### What issues does this PR fix or reference?
@W-11111405@