### PR TITLE
Change analyticsdx-template-lint to @salesforce

### DIFF
--- a/extensions/analyticsdx-vscode-templates/package.json
+++ b/extensions/analyticsdx-vscode-templates/package.json
@@ -26,8 +26,8 @@
     "Other"
   ],
   "dependencies": {
+    "@salesforce/analyticsdx-template-lint": "0.8.2",
     "@salesforce/salesforcedx-utils-vscode": "file:../../lib/salesforcedx-utils-vscode.tgz",
-    "analyticsdx-template-lint": "0.8.2",
     "jsonc-parser": "3.0.0",
     "lodash.isequal": "4.5.0",
     "request-light": "0.5.8",

--- a/extensions/analyticsdx-vscode-templates/src/constants.ts
+++ b/extensions/analyticsdx-vscode-templates/src/constants.ts
@@ -8,7 +8,7 @@
 import { newFileExtensionFilter } from './util/utils';
 
 // re-export these from the linter library, in case we need to muck with them in the future
-export { ERRORS, LINTER_SOURCE_ID, TEMPLATE_INFO } from 'analyticsdx-template-lint';
+export { ERRORS, LINTER_SOURCE_ID, TEMPLATE_INFO } from '@salesforce/analyticsdx-template-lint';
 
 // Note: keep these in-sync with the publisher and name in package.json
 export const EXTENSION_PUBLISHER = 'salesforce';

--- a/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
@@ -342,7 +342,7 @@ export class TemplateEditingManager extends Disposable {
   constructor(context: vscode.ExtensionContext, output?: vscode.OutputChannel) {
     super();
     this.extensionPath = context.extensionPath;
-    const schemasPath = 'node_modules/analyticsdx-template-lint/out/src/schemas';
+    const schemasPath = 'node_modules/@salesforce/analyticsdx-template-lint/out/src/schemas';
     // TODO: warn if any of the schemas are missing
     this.baseSchemaPath = vscode.Uri.file(context.asAbsolutePath(`${schemasPath}/adx-template-json-base-schema.json`));
     this.templateInfoSchemaPath = vscode.Uri.file(context.asAbsolutePath(`${schemasPath}/template-info-schema.json`));

--- a/extensions/analyticsdx-vscode-templates/src/templateLinter.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateLinter.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TemplateLinter, TemplateLinterDiagnosticSeverity } from 'analyticsdx-template-lint';
+import { TemplateLinter, TemplateLinterDiagnosticSeverity } from '@salesforce/analyticsdx-template-lint';
 import { getNodePath, Node as JsonNode } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { LINTER_SOURCE_ID } from './constants';

--- a/extensions/analyticsdx-vscode-templates/src/util/jsoncUtils.ts
+++ b/extensions/analyticsdx-vscode-templates/src/util/jsoncUtils.ts
@@ -7,7 +7,7 @@
 
 import { FormattingOptions, getNodePath, JSONPath, Node as JsonNode } from 'jsonc-parser';
 
-export { matchJsonNodeAtPattern, matchJsonNodesAtPattern } from 'analyticsdx-template-lint';
+export { matchJsonNodeAtPattern, matchJsonNodesAtPattern } from '@salesforce/analyticsdx-template-lint';
 
 const jsonIdRegex = /^[A-Za-z][-A-Za-z0-9_]*$/;
 /**

--- a/extensions/analyticsdx-vscode-templates/src/util/templateUtils.ts
+++ b/extensions/analyticsdx-vscode-templates/src/util/templateUtils.ts
@@ -8,7 +8,7 @@
 import * as vscode from 'vscode';
 import { uriBasename, uriDirname, uriStat } from './vscodeUtils';
 
-export { isValidVariableName } from 'analyticsdx-template-lint';
+export { isValidVariableName } from '@salesforce/analyticsdx-template-lint';
 
 /** Traverse up from the file until you find the template-info.json, without leaving the vscode workspace folders.
  * @return the file uri, or undefined if not found (i.e. file is not part of a template)

--- a/extensions/analyticsdx-vscode-templates/src/util/utils.ts
+++ b/extensions/analyticsdx-vscode-templates/src/util/utils.ts
@@ -7,7 +7,7 @@
 
 import { posix as path } from 'path';
 
-export { isValidRelpath } from 'analyticsdx-template-lint';
+export { isValidRelpath } from '@salesforce/analyticsdx-template-lint';
 
 const whitespaceRe = /^\s$/;
 export function isWhitespaceChar(ch: string) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "watch": "lerna run --parallel watch",
     "eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
     "reformat": "node scripts/reformat-with-prettier.js",
-    "vscode:package": "lerna exec --scope analyticsdx-template-lint -- npm prune --production && lerna run vscode:package --concurrency 1 && node scripts/reformat-with-prettier",
+    "vscode:package": "lerna exec --scope @salesforce/analyticsdx-template-lint -- npm prune --production && lerna run vscode:package --concurrency 1 && node scripts/reformat-with-prettier",
     "vscode:sha256": "lerna run vscode:sha256 --concurrency 1",
     "vscode:publish": "lerna run vscode:publish --concurrency 1",
     "update-versions": "node scripts/update-versions.js",

--- a/packages/analyticsdx-template-lint/package.json
+++ b/packages/analyticsdx-template-lint/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.8.2",
   "publisher": "salesforce",
-  "name": "analyticsdx-template-lint",
+  "name": "@salesforce/analyticsdx-template-lint",
   "displayName": "Salesforce Analytics Template Lint",
   "description": "Provides a linting api for Salesforce/TableauCRM analytics templates",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Fixes the [security alert on analyticsdx-template-lint](https://github.com/forcedotcom/analyticsdx-vscode/security/dependabot/3).

This is a false positive security alert, triggered due to someone publishing a fake malware [analyticsdx-template-lint package to npm](https://www.npmjs.com/package/analyticsdx-template-lint), which npm caught, removed, and then published an empty marker package for, which triggered the github alert. However, in this repo, analytics-template-lint is an internal source folder referenced via lerna and never downloaded from npm, so it was not actually affected by the npm security alert.

In any case, switching the name of the internal source package to `@salesforce/analyticsdx-template-lint` should
1. Make the false-positive security alert go away.
2. Prevent this case in the future since only validated people should be able to publish to the `@salesforce` npm scope.