### PR TITLE
Fix highlighted text when showing variable name hover

### DIFF
--- a/extensions/analyticsdx-vscode-templates/src/variables/hover.ts
+++ b/extensions/analyticsdx-vscode-templates/src/variables/hover.ts
@@ -105,7 +105,7 @@ export abstract class VariableRefHoverProvider implements vscode.HoverProvider {
         const tree = parseTree(varDoc.getText());
         const txt = hoverMarkdownForVariable(varname, tree && findNodeAtLocation(tree, [varname]));
         if (txt) {
-          return new vscode.Hover(txt, rangeForNode(location.previousNode, varDoc));
+          return new vscode.Hover(txt, rangeForNode(location.previousNode, document));
         }
       }
     }


### PR DESCRIPTION
In files that reference variables (i.e. ui, layout, auto-install), when the user
hovered, it would show the hover w/ the variable info, but the wrong text in the
editor would be highlighted due to using the wrong file to calculate the hover's
range.
