### PR TITLE
enumsLabels, and csv size validation

### DIFF
--- a/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/createDashboardLWC.test.ts
+++ b/extensions/analyticsdx-vscode-core/test/vscode-integration/commands/createDashboardLWC.test.ts
@@ -87,7 +87,12 @@ describe('createDashboardLWC.ts', () => {
   afterEach(async () => {
     if (lwcDir) {
       if (await uriExists(lwcDir)) {
-        await vscode.workspace.fs.delete(lwcDir, { recursive: true, useTrash: false });
+        try {
+          await vscode.workspace.fs.delete(lwcDir, { recursive: true, useTrash: false });
+        } catch (ignore) {
+          // these sometimes unrelatedly fail to delete on Windows tests on Github, but we don't really care about it
+          // since we gen a unique name each time and .gitignore them
+        }
       }
     }
   });

--- a/extensions/analyticsdx-vscode-templates/src/templateLinter.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateLinter.ts
@@ -46,6 +46,17 @@ export class VscodeTemplateLinter extends TemplateLinter<vscode.Uri, vscode.Text
     }
   }
 
+  protected override async uriStat(
+    uri: vscode.Uri
+  ): Promise<{ ctime: number; mtime: number; size: number } | undefined> {
+    const stat = await uriStat(uri);
+    if (!stat) {
+      return undefined;
+    } else {
+      return { ctime: stat.ctime, mtime: stat.mtime, size: stat.size };
+    }
+  }
+
   protected override async getDocument(uri: vscode.Uri): Promise<vscode.TextDocument> {
     return vscode.workspace.openTextDocument(uri);
   }

--- a/packages/analyticsdx-template-lint/src/constants.ts
+++ b/packages/analyticsdx-template-lint/src/constants.ts
@@ -13,6 +13,8 @@ export const LINTER_SOURCE_ID = 'adx-template';
 export const JSON_SOURCE_ID = 'json';
 /** Diagnostic source id for json schema issues. */
 export const JSON_SCHEMA_SOURCE_ID = 'json-schema';
+/** The maximum supported size of CSV external files (in bytes). */
+export const LINTER_MAX_EXTERNAL_FILE_SIZE = 10_000_000;
 
 // Note: this should be in sync with the paths below
 const assetAttrPaths = [
@@ -139,6 +141,8 @@ export const ERRORS = Object.freeze({
   TMPL_RECIPES_MIN_ASSET_VERSION: 'tmpl-20',
   /** layoutDefinition is only for data templates */
   TMPL_LAYOUT_UNSUPPORTED: 'tmpl-21',
+  /** externalFile csv file is larger then LINTER_MAX_CSV_FILE_SIZE */
+  TMPL_EXTERNAL_FILE_TOO_BIG: 'tmpl-22',
 
   /** Unknown variable in values in autoInstallDefinition. */
   AUTO_INSTALL_UNKNOWN_VARIABLE: 'auto-1',

--- a/packages/analyticsdx-template-lint/src/schemas/variables-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/variables-schema.json
@@ -77,6 +77,9 @@
         "enums": {
           "doNotSuggest": true
         },
+        "enumsLabels": {
+          "doNotSuggest": true
+        },
         "min": {
           "doNotSuggest": true
         },
@@ -128,6 +131,15 @@
                 "type": "string"
               },
               "doNotSuggest": false
+            },
+            "enumsLabels": {
+              "type": ["array", "null"],
+              "minItems": 0,
+              "description": "The optional display labels for the enumerated values. Only available in Summer '23 release.",
+              "items": {
+                "type": ["string", "null"]
+              },
+              "doNotSuggest": true
             }
           },
           "required": ["type"]
@@ -155,6 +167,15 @@
                 "type": ["number", "integer"]
               },
               "doNotSuggest": false
+            },
+            "enumsLabels": {
+              "type": ["array", "null"],
+              "minItems": 0,
+              "description": "The optional display labels for the enumerated values. Only available in Summer '23 release.",
+              "items": {
+                "type": ["string", "null"]
+              },
+              "doNotSuggest": true
             }
           },
           "required": ["type"]

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/variables/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/variables/valid/all-fields.json
@@ -7,7 +7,7 @@
     "required": true,
     "variableType": {
       "type": "BooleanType",
-      "enums": ["One", "Two", "Three", "default value"]
+      "enums": [true, false]
     },
     "defaultValue": "default value"
   },
@@ -19,7 +19,8 @@
     "required": false,
     "variableType": {
       "type": "StringType",
-      "enums": ["One", "Two", "Three", "default value"]
+      "enums": ["one", "two", "three", "default value"],
+      "enumsLabels": ["One", null, "Three"]
     },
     "defaultValue": "default value"
   },
@@ -29,6 +30,7 @@
     "variableType": {
       "type": "NumberType",
       "enums": [1, 2, 3],
+      "enumsLabels": [null, "Two"],
       "min": 1,
       "max": 3
     }
@@ -163,7 +165,8 @@
       "type": "ArrayType",
       "itemsType": {
         "type": "StringType",
-        "enums": ["Leads", "Campaigns", "Campaign Members"]
+        "enums": ["leadz", "camps", "campmem", "Foo"],
+        "enumsLabels": ["Leads", "Campaigns", "Campaign Members", null]
       },
       "sizeLimit": {
         "max": 10,
@@ -236,6 +239,17 @@
       "itemsType": {
         "type": "NumberType",
         "max": 1000000
+      }
+    }
+  },
+  "numberenumsarray": {
+    "variableType": {
+      "type": "ArrayType",
+      "itemsType": {
+        "type": "NumberType",
+        "max": 1000000,
+        "enums": [1, 2, 4, 8, 16],
+        "enumsLabels": ["One", null, "2^2"]
       }
     }
   },

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/variables/valid/minimum-vars.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/variables/valid/minimum-vars.json
@@ -1,3 +1,17 @@
 {
-  "defaultVar": {}
+  "defaultVar": {},
+  "nullEnumsLabelsStringType": {
+    "variableType": {
+      "type": "StringType",
+      "enums": [],
+      "enumsLabels": null
+    }
+  },
+  "nullEnumsLabelsNumberType": {
+    "variableType": {
+      "type": "NumberType",
+      "enums": [],
+      "enumsLabels": null
+    }
+  }
 }


### PR DESCRIPTION
### What does this PR do?
- Adds support for new `enumsLabels` field on `StringType` and `NumberType` template variables. This won't be Not publically available until the Summer '23 release.
- Adds a warning on CSV `externalFiles` larger than 10,000,000 bytes, which will be truncated during app creation.

### What issues does this PR fix or reference?
@W-12573837