### PR TITLE
Updates for readinessDefinition file validation and editing, bug fixes

### DIFF
--- a/extensions/analyticsdx-vscode-templates/src/readiness/actions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/readiness/actions.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as vscode from 'vscode';
+import { ERRORS, LINTER_SOURCE_ID } from '../constants';
+import { TemplateDirEditing } from '../templateEditing';
+import { argsFrom } from '../util/vscodeUtils';
+import { VariableRefCodeActionProvider } from '../variables';
+
+/** Provides quick fixes for unrecognized variable name errors in readiness.json's. */
+export class ReadinessVariableCodeActionProvider extends VariableRefCodeActionProvider {
+  constructor(template: TemplateDirEditing) {
+    super(template);
+  }
+
+  protected isSupportedDocument(document: vscode.TextDocument) {
+    return this.template.isReadinessDefinitionFile(document.uri);
+  }
+
+  protected isSupportedDiagnostic(d: vscode.Diagnostic) {
+    if (d.source === LINTER_SOURCE_ID && d.code === ERRORS.READINESS_UNKNOWN_VARIABLE) {
+      const args = argsFrom(d);
+      if (args) {
+        return {
+          name: typeof args.name === 'string' ? args.name : undefined,
+          match: typeof args.match === 'string' ? args.match : undefined
+        };
+      }
+    }
+    return undefined;
+  }
+}

--- a/extensions/analyticsdx-vscode-templates/src/readiness/index.ts
+++ b/extensions/analyticsdx-vscode-templates/src/readiness/index.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+export * from './actions';
 export * from './completions';
 export * from './definitions';
 export * from './hovers';

--- a/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
@@ -49,6 +49,7 @@ import {
   LayoutVariableHoverProvider
 } from './layout';
 import {
+  ReadinessVariableCodeActionProvider,
   ReadinessVariableCompletionItemProviderDelegate,
   ReadinessVariableDefinitionProvider,
   ReadinessVariableHoverProvider
@@ -371,6 +372,11 @@ export class TemplateDirEditing extends Disposable {
           providedCodeActionKinds: AutoInstallVariableCodeActionProvider.providedCodeActionKinds
         }
       ),
+
+      // hookup quick fixes for variable names in readiness.json's
+      vscode.languages.registerCodeActionsProvider(relatedFileSelector, new ReadinessVariableCodeActionProvider(this), {
+        providedCodeActionKinds: ReadinessVariableCodeActionProvider.providedCodeActionKinds
+      }),
 
       // hookup hover text
       vscode.languages.registerHoverProvider(relatedFileSelector, new UiVariableHoverProvider(this)),

--- a/packages/analyticsdx-template-lint/src/constants.ts
+++ b/packages/analyticsdx-template-lint/src/constants.ts
@@ -175,6 +175,8 @@ export const ERRORS = Object.freeze({
 
   /** ApexCallback readiness definition but template has no apexCallback */
   READINESS_NO_APEX_CALLBACK: 'read-1',
+  /** Unknown variable name in values in readinessDefinition  */
+  READINESS_UNKNOWN_VARIABLE: 'read-2',
 
   /** Duplicate constant in rules file(s) */
   RULES_DUPLICATE_CONSTANT: 'rules-1',

--- a/packages/analyticsdx-template-lint/src/linter.ts
+++ b/packages/analyticsdx-template-lint/src/linter.ts
@@ -386,7 +386,7 @@ export abstract class TemplateLinter<
     if (valuesNode?.type === 'object' && valuesNode.children && valuesNode.children.length > 0) {
       const variableTypes = (await this.loadVariableTypesForTemplate(templateInfo)) || {};
       const fuzzySearch = fuzzySearcher({
-        // make an iterable, to lazily call Object.keys() on if fuzzySearch is called
+        // make an iterable, to lazily call Object.keys() only if fuzzySearch is called
         [Symbol.iterator]: () => Object.keys(variableTypes).filter(isValidVariableName)[Symbol.iterator]()
       });
       valuesNode.children.forEach(valueNode => {

--- a/packages/analyticsdx-template-lint/src/linter.ts
+++ b/packages/analyticsdx-template-lint/src/linter.ts
@@ -376,6 +376,38 @@ export abstract class TemplateLinter<
     });
   }
 
+  private async lintVariablesNamesInObject(
+    templateInfo: JsonNode,
+    doc: Document,
+    valuesNode: JsonNode | undefined,
+    // errorCode should one of the values in ERRORS
+    errorCode: typeof ERRORS[keyof typeof ERRORS]
+  ) {
+    if (valuesNode?.type === 'object' && valuesNode.children && valuesNode.children.length > 0) {
+      const variableTypes = (await this.loadVariableTypesForTemplate(templateInfo)) || {};
+      const fuzzySearch = fuzzySearcher({
+        // make an iterable, to lazily call Object.keys() on if fuzzySearch is called
+        [Symbol.iterator]: () => Object.keys(variableTypes).filter(isValidVariableName)[Symbol.iterator]()
+      });
+      valuesNode.children.forEach(valueNode => {
+        const nameNode = valueNode.children?.[0];
+        if (nameNode?.type === 'string' && typeof nameNode.value === 'string') {
+          const name = nameNode.value;
+          if (!variableTypes[name]) {
+            let mesg = `Cannot find variable '${name}'`;
+            const [match] = fuzzySearch(name);
+            const args: Record<string, any> = { name };
+            if (match && match.length > 0) {
+              args.match = match;
+              mesg += `, did you mean '${match}'`;
+            }
+            this.addDiagnostic(doc, mesg, errorCode, nameNode, { args });
+          }
+        }
+      });
+    }
+  }
+
   // TODO: figure out how to do incremental linting (or if we even should)
   // Currently, this and #opened() always starts with the template-info.json at-or-above the modified file, and then
   // does a full lint of the whole template folder, which ends up parsing the template-info and every related file to
@@ -887,48 +919,16 @@ export abstract class TemplateLinter<
   private async lintAutoInstall(templateInfo: JsonNode): Promise<void> {
     const { doc, json: autoInstall } = await this.loadTemplateRelPathJson(templateInfo, ['autoInstallDefinition']);
     if (doc && autoInstall) {
-      await this.lintAutoInstallAppConfigurationValues(templateInfo, doc, autoInstall);
-    }
-  }
+      await this.lintVariablesNamesInObject(
+        templateInfo,
+        doc,
+        matchJsonNodeAtPattern(autoInstall, ['configuration', 'appConfiguration', 'values']),
+        ERRORS.AUTO_INSTALL_UNKNOWN_VARIABLE
+      );
 
-  private async lintAutoInstallAppConfigurationValues(
-    templateInfo: JsonNode,
-    doc: Document,
-    autoInstall: JsonNode
-  ): Promise<void> {
-    const valuesNode = matchJsonNodeAtPattern(autoInstall, ['configuration', 'appConfiguration', 'values']);
-    // if there's values specified, load the variableDefinition file and make sure they line up
-    if (valuesNode && valuesNode.children && valuesNode.children.length > 0) {
-      const variableTypes = (await this.loadVariableTypesForTemplate(templateInfo)) || {};
-      const fuzzySearch = fuzzySearcher({
-        // make an Iterable, to lazily call Object.keys() only if fuzzySearch is called
-        [Symbol.iterator]: () =>
-          Object.keys(variableTypes)
-            // also, only include valid variable names in the fuzzy search
-            .filter(isValidVariableName)
-            [Symbol.iterator]()
-      });
-      valuesNode.children.forEach(valueNode => {
-        const nameNode = valueNode.children?.[0];
-        if (nameNode && nameNode.type === 'string' && typeof nameNode.value === 'string') {
-          const name = nameNode.value;
-          if (!variableTypes[name]) {
-            let mesg = `Cannot find variable '${name}'`;
-            // see if there's a variable w/ a similar name
-            const [match] = fuzzySearch(name);
-            const args: Record<string, any> = { name };
-            if (match && match.length > 0) {
-              args.match = match;
-              mesg += `, did you mean '${match}'?`;
-            }
-            this.addDiagnostic(doc, mesg, ERRORS.AUTO_INSTALL_UNKNOWN_VARIABLE, nameNode, { args });
-          }
-        }
-      });
+      // TODO: if variableDefinition has variable w/o a defaultValue and no apexCallback specified, and
+      // if that variable isn't specified in the autoInstall values, we should warn on that
     }
-
-    // TODO: if variableDefinition has variable w/o a defaultValue and no apexCallback specified, and
-    // if that variable isn't specified in the autoInstall values, we should warn on that
   }
 
   private async lintVariables(templateInfo: JsonNode): Promise<void> {
@@ -1106,7 +1106,17 @@ export abstract class TemplateLinter<
   private async lintReadiness(templateInfo: JsonNode) {
     const { doc, json: readiness } = await this.loadTemplateRelPathJson(templateInfo, ['readinessDefinition']);
     if (doc && readiness) {
+      // start this one
+      const p = this.lintVariablesNamesInObject(
+        templateInfo,
+        doc,
+        matchJsonNodeAtPattern(readiness, ['values']),
+        ERRORS.READINESS_UNKNOWN_VARIABLE
+      );
+      // run this one
       this.lintReadinessApexCallbacks(templateInfo, doc, readiness);
+      // wait for the async one
+      return p;
     }
   }
 

--- a/packages/analyticsdx-template-lint/src/schemas/auto-install-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/auto-install-schema.json
@@ -87,7 +87,7 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^[a-zA-Z_][a-zA-Z0-9_]*": {}
+                "^[a-zA-Z_][a-zA-Z0-9_]*$": {}
               },
               "description": "Variable values for the app. Names should match variables defined in the variableDefinition file."
             }

--- a/packages/analyticsdx-template-lint/src/schemas/auto-install-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/auto-install-schema.json
@@ -85,7 +85,10 @@
             },
             "values": {
               "type": "object",
-              "additionalProperties": true,
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z_][a-zA-Z0-9_]*": {}
+              },
               "description": "Variable values for the app. Names should match variables defined in the variableDefinition file."
             }
           }

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -345,7 +345,7 @@
                     "type": "string",
                     "description": "Variable name. Must match name of variable defined in variableDefinition file.",
                     "$comment": "The variableDefinition file's fields have to match this regex, so match it here, too.",
-                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]+$",
+                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
                     "doNotSuggest": false
                   }
                 },

--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -11,7 +11,10 @@
     "values": {
       "description": "Default values for variables when computing readiness. Any values passed into the readiness check call will override these.",
       "type": ["null", "object"],
-      "additionalProperties": true,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z_][a-zA-Z0-9_]*": {}
+      },
       "defaultSnippets": [{ "label": "New values", "body": { "${1}": "${2}" } }]
     },
     "templateRequirements": {

--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -13,7 +13,7 @@
       "type": ["null", "object"],
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z_][a-zA-Z0-9_]*": {}
+        "^[a-zA-Z_][a-zA-Z0-9_]*$": {}
       },
       "defaultSnippets": [{ "label": "New values", "body": { "${1}": "${2}" } }]
     },

--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -26,10 +26,10 @@
         "properties": {
           "expression": {
             "type": "string",
-            "description": "The ${...} expression to evaluate. This can access variables values as Variables.[name], and computed readiness definition values as Readiness.[name].",
+            "description": "The ${...} expression to evaluate. This can access variable values as Variables.[name], constants from templateToApp rules files as Constants.[name], and computed readiness definition values as Readiness.[name].",
             "examples": [
               "${Readiness.sobjectCount > Variables.minimumCount}",
-              "${Readiness.datasetRowCount >= 4000}",
+              "${Readiness.datasetRowCount >= Constants.minNumRows}",
               "${Readiness.apexResult.name == 'requiredName'}"
             ]
           },
@@ -60,18 +60,18 @@
           },
           "successMessage": {
             "type": ["null", "string"],
-            "description": "Optional message to return when the check in the expression evaluates to true. This can access variables values as Variables.[name], and computed readiness definition values as Readiness.[name].",
+            "description": "Optional message to return when the expression evaluates to true. This can access variable values as Variables.[name], constants from templateToApp rules files as Constants.[name], and computed readiness definition values as Readiness.[name].",
             "examples": [
               "Succesfully found ${Readiness.sobjectCount} ${Variables.sobject.objectName} objects.",
-              "Dataset ${App.Datasets.Opptys.Name} has at least ${Readiness.rowCount} rows"
+              "Dataset ${App.Datasets.Opptys.Name} has at least ${Constants.rowCount} rows"
             ]
           },
           "failMessage": {
             "type": ["null", "string"],
-            "description": "Optional message to return when the check in the expression evaluates to false. This can access variables values as Variables.[name], and computed readiness definition values as Readiness.[name].",
+            "description": "Optional message to return when the expression evaluates to false. This can access variable values as Variables.[name], constants from templateToApp rules files as Constants.[name], and computed readiness definition values as Readiness.[name].",
             "examples": [
               "Too many ${Variables.sobject.objectName} objects, found ${Readiness.sobjectCount}",
-              "Dataset ${App.Datasets.Opptys.Name} only has ${Readiness.rowCount} rows"
+              "${App.Datasets.Opptys.Name} only has ${Readiness.rowCount} rows, expected ${Constants.minRowCount}"
             ]
           },
           "image": {
@@ -122,7 +122,7 @@
       "defaultSnippets": [{ "label": "[]", "body": [] }]
     },
     "definition": {
-      "description": "The readiness definition checks for this template. Each named entry here will be executed during the readiness check and available as ${Readiness.[name]} in the templateRequirements expression, the conditions in template-info, and rules.",
+      "description": "The readiness definition checks for this template. Each named entry here will be executed during the readiness check and available as Readiness.[name] in the templateRequirements expression, the conditions in template-info.json, and rules.",
       "type": ["null", "object"],
       "additionalProperties": {
         "description": "A readiness definition.",
@@ -195,7 +195,7 @@
             "type": { "const": "AppDatasetRowCount" },
             "dataset": {
               "type": "string",
-              "description": "The name or id of the dataset that will be created by the template. This can be a ${} expression.",
+              "description": "The name or id of the dataset that will be created by the template. This can be a ${...} expression.",
               "doNotSuggest": false
             },
             "filters": {
@@ -223,7 +223,8 @@
             "type": { "const": "ApexCallout" },
             "method": {
               "type": "string",
-              "description": "The name of the method on the apexCallback class. This method must be annotated with @InvocableMethod. Return value will be serialized as a Map or primitive value and avaiable as ${Readiness.definitionName}.",
+              "description": "The name of the method on the apexCallback class. This method must non-static and global. Return value will be serialized as a Map or primitive value and avaiable as ${Readiness.[definitionName]}.",
+              "minLength": 0,
               "doNotSuggest": false
             },
             "arguments": {

--- a/packages/analyticsdx-template-lint/src/schemas/template-info-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/template-info-schema.json
@@ -1165,7 +1165,8 @@
           },
           "name": {
             "type": "string",
-            "description": "The dependent template name."
+            "description": "The dependent template name.",
+            "minLength": 1
           },
           "templateVersion": {
             "type": ["null", "string"],

--- a/packages/analyticsdx-template-lint/src/schemas/ui-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/ui-schema.json
@@ -82,7 +82,7 @@
                   "type": "string",
                   "description": "Variable name. Must match name of variable defined in variableDefinition file.",
                   "$comment": "The variableDefinition file's fields have to match this regex, so match it here, too.",
-                  "pattern": "^[a-zA-Z_][a-zA-Z0-9_]+$"
+                  "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
                 },
                 "visibility": {
                   "description": "Controls if the variable is visible. Value must be 'Disabled', 'Hidden', 'Visible', or a {{...}} expression against variables that evaluates to one of those or true (Visible) or false (Hidden).",

--- a/packages/analyticsdx-template-lint/src/schemas/variables-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/variables-schema.json
@@ -7,7 +7,7 @@
   "allowComments": true,
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-zA-Z_][a-zA-Z0-9_]+$": {
+    "^[a-zA-Z_][a-zA-Z0-9_]*$": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/packages/analyticsdx-template-lint/src/utils.ts
+++ b/packages/analyticsdx-template-lint/src/utils.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import Fuse from 'fuse.js';
 import { JSONPath, Node as JsonNode } from 'jsonc-parser';
 
-const jsonIdRegex = /^[A-Za-z][-A-Za-z0-9_]*$/;
+const jsonIdRegex = /^[A-Za-z][A-Za-z0-9_]*$/;
 /**
  * Convert the specified path of a node to a an javascript-style expression (e.g. foo.bar[2])
  */
@@ -24,7 +24,7 @@ export function jsonPathToString(path: JSONPath): string {
         }
         buf += part;
       } else {
-        // otherwise do associate-array style, with double-quotes
+        // otherwise do associative-array style, with double-quotes
         buf += '["' + part.replace(/"/g, '\\"') + '"]';
       }
     } else {
@@ -183,7 +183,7 @@ export function isValidRelpath(relpath: string | undefined | null): boolean {
   );
 }
 
-const varNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]+$/;
+const varNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 /** Tell if the specified value is a valid template variable name. */
 export function isValidVariableName(name: string): boolean {
   return varNameRegex.test(name);

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidAutoInstallJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidAutoInstallJsonTests.ts
@@ -22,7 +22,8 @@ describe('auto-install-schema.json finds errors in', () => {
       'error',
       'hooks[0].error',
       'configuration.error',
-      'configuration.appConfiguration.error'
+      'configuration.appConfiguration.error',
+      'configuration.appConfiguration.values["-"]'
     );
     errors.expectNoMissingProps();
     errors.expectNoUnrecognizedErrors();

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidReadinessJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidReadinessJsonTests.ts
@@ -25,6 +25,7 @@ describe('readiness-schema.json finds errors in', () => {
     errors.expectInvalidProps(
       false,
       'error',
+      'values["-"]',
       'templateRequirements[0].error',
       'templateRequirements[1].image.error',
       'definition.foo.error'

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/auto-install/invalid/invalid-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/auto-install/invalid/invalid-fields.json
@@ -16,7 +16,9 @@
       "deleteAppOnConstructionFailure": true,
       "values": {
         "value1": "testString",
-        "value2": false
+        "value2": false,
+        "a": { "sobjectName": "Case" },
+        "-": "bad variable name"
       }
     },
     "parentRequestIds": ["one", "two", "three"]

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/auto-install/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/auto-install/valid/all-fields.json
@@ -13,7 +13,9 @@
       "deleteAppOnConstructionFailure": true,
       "values": {
         "value1": "testString",
-        "value2": false
+        "value2": false,
+        "a": { "sobjectName": "Case" },
+        "_": []
       }
     },
     "parentRequestIds": ["one", "two", "three"]

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/invalid/invalid-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/invalid/invalid-fields.json
@@ -1,5 +1,9 @@
 {
   "error": "This should be a warning",
+  "values": {
+    "a": { "sobjectName": "Case" },
+    "-": "bad variable name"
+  },
   "templateRequirements": [
     {
       "error": "This should be a warning",

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
@@ -5,7 +5,8 @@
     "num": 123,
     "obj": { "foo": "bar" },
     "array": ["baz"],
-    "op": "Equal"
+    "op": "Equal",
+    "_": 4.2
   },
   "templateRequirements": [
     {

--- a/packages/analyticsdx-template-lint/test/unit/utils.test.ts
+++ b/packages/analyticsdx-template-lint/test/unit/utils.test.ts
@@ -60,6 +60,8 @@ describe('utils', () => {
         'a+b',
         'a b',
         'a/b',
+        '-',
+        'a-b',
         "'ab'",
         '"ab"',
         'true',
@@ -71,7 +73,7 @@ describe('utils', () => {
         'field'
       ];
       expect(jsonPathToString(path)).to.be.equals(
-        'root["000"]["a+b"]["a b"]["a/b"]["\'ab\'"]["\\"ab\\""]["true"]["a.b"]["a,b"]["a:b"]["[]"]["()"].field'
+        'root["000"]["a+b"]["a b"]["a/b"]["-"]["a-b"]["\'ab\'"]["\\"ab\\""]["true"]["a.b"]["a,b"]["a:b"]["[]"]["()"].field'
       );
     });
 
@@ -509,13 +511,13 @@ describe('utils', () => {
   });
 
   describe('isValidVariableName()', () => {
-    ['_a', '_Z', 'b0', 'abcde_g42hi_'].forEach(name => {
+    ['a', '_', '_a', '_Z', 'b0', 'abcde_g42hi_'].forEach(name => {
       it(`matches '${name}'`, () => {
         expect(isValidVariableName(name)).to.be.true;
       });
     });
 
-    ['0abc', '_', ' ', ' a', 'a ', 'a b', 'y+z'].forEach(name => {
+    ['0abc', '-', ' ', ' a', 'a ', 'a b', 'y+z', 'y-z'].forEach(name => {
       it(`doesn't '${name}'`, () => {
         expect(isValidVariableName(name)).to.be.false;
       });


### PR DESCRIPTION
### What does this PR do?

In the readiness file:
- Update the json-schema based hover text on readiness file fields
- Validate the names in `values` are valid, existing variable names
- Add quick fixes on invalid names in `values`
- Fix the regex for matching on valid variable names, to support single-char names (e.g. `a`, `_`), and to warn on names that contain `-` (which are actually invalid)
- Don't show variable type hover text on invalid variable names

In template-info.json:
- Warn if template dependency `name` is empty string

### What issues does this PR fix or reference?
@W-12740486@, @W-12651097@
