### PR TITLE
fix(@W-13223816): wrong warning on invalid defaultStatus

### DIFF
--- a/extensions/analyticsdx-vscode-core/package.json
+++ b/extensions/analyticsdx-vscode-core/package.json
@@ -29,7 +29,7 @@
     "@salesforce/salesforcedx-utils-vscode": "file:../../lib/salesforcedx-utils-vscode.tgz",
     "@salesforce/templates": "54.7.0",
     "glob": "8.0.3",
-    "semver": "7.3.8",
+    "semver": "7.5.4",
     "tmp": "0.2.1",
     "which": "3.0.0"
   },
@@ -39,7 +39,7 @@
     "@types/glob": "7.2.0",
     "@types/mocha": "10.0.1",
     "@types/node": "16.18.14",
-    "@types/semver": "7.3.13",
+    "@types/semver": "7.5.0",
     "@types/sinon": "10.0.13",
     "@types/tmp": "0.2.2",
     "@types/vscode": "1.74.0",

--- a/packages/analyticsdx-template-lint/src/schemas/template-info-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/template-info-schema.json
@@ -1143,9 +1143,6 @@
         "defaultStatus": {
           "oneOf": [
             {
-              "type": "null"
-            },
-            {
               "type": "string",
               "enum": ["Fail", "Warn", "Skip"],
               "enumDescriptions": [
@@ -1153,6 +1150,9 @@
                 "Warn about the failure but let the app creation continue.",
                 "Skip this asset and let the app creation continue."
               ]
+            },
+            {
+              "type": "null"
             }
           ]
         }


### PR DESCRIPTION
### What does this PR do?

Fix to show the better warning message on an invalid `onFailure.defaultStatus`.
Also updating `semver` version for [non-affecting security issue](https://github.com/forcedotcom/analyticsdx-vscode/security/dependabot/5).

### What issues does this PR fix or reference?
@W-13223816
