### PR TITLE
Add support for the navigation panel in the template layout

### DIFF
--- a/extensions/analyticsdx-vscode-templates/src/layout/actions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/layout/actions.ts
@@ -36,7 +36,7 @@ export class LayoutVariableCodeActionProvider extends VariableRefCodeActionProvi
   }
 }
 
-/** Provide quick fixes for unrecongized variable tile keys in layout.json's. */
+/** Provide quick fixes for unrecognized variable tile keys in layout.json's. */
 export class LayoutVariableTileCodeActionProvider implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
 

--- a/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
@@ -58,18 +58,14 @@ import {
   ReadinessVariableHoverProvider
 } from './readiness';
 import { telemetryService } from './telemetry';
-import {
-  CreateFolderShareCodeActionProvider,
-  CreateRelPathFileCodeActionProvider,
-  RemoveJsonPropertyDiagnosticCodeActionProvider
-} from './templateInfo/actions';
+import { CreateFolderShareCodeActionProvider, CreateRelPathFileCodeActionProvider } from './templateInfo/actions';
 import {
   UiVariableCodeActionProvider,
   UiVariableCompletionItemProviderDelegate,
   UiVariableDefinitionProvider,
   UiVariableHoverProvider
 } from './ui';
-import { RemoveJsonPropertyCodeActionProvider } from './util/actions';
+import { RemoveJsonPropertyCodeActionProvider, RemoveJsonPropertyDiagnosticCodeActionProvider } from './util/actions';
 import { JsonCompletionItemProvider, newRelativeFilepathDelegate } from './util/completions';
 import { JsonAttributeRelFilePathDefinitionProvider } from './util/definitions';
 import { Disposable } from './util/disposable';

--- a/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
@@ -334,9 +334,9 @@ export class TemplateDirEditing extends Disposable {
       vscode.languages.registerDefinitionProvider(relatedFileSelector, new LayoutVariableDefinitionProvider(this)),
       // hookup Go To Definition from variable tiles key in layout.json to variables.json
       vscode.languages.registerDefinitionProvider(relatedFileSelector, new LayoutVariableTileDefinitionProvider(this)),
-      // hookup Go To Definition from varaibles name in auto-install.json to variables.json
+      // hookup Go To Definition from variables name in auto-install.json to variables.json
       vscode.languages.registerDefinitionProvider(relatedFileSelector, new AutoInstallVariableDefinitionProvider(this)),
-      // hookup Go To Definition from varaibles name in auto-install.json to readiness.json
+      // hookup Go To Definition from variables name in auto-install.json to readiness.json
       vscode.languages.registerDefinitionProvider(relatedFileSelector, new ReadinessVariableDefinitionProvider(this)),
 
       vscode.languages.registerCompletionItemProvider(
@@ -373,6 +373,15 @@ export class TemplateDirEditing extends Disposable {
         new LayoutVariableTileCodeActionProvider(this),
         {
           providedCodeActionKinds: LayoutVariableTileCodeActionProvider.providedCodeActionKinds
+        }
+      ),
+
+      // hookup quick fixes for removing unnecessary navigation objects in layout.json
+      vscode.languages.registerCodeActionsProvider(
+        relatedFileSelector,
+        new RemoveJsonPropertyDiagnosticCodeActionProvider(ERRORS.LAYOUT_PAGE_UNNECESSARY_NAVIGATION_OBJECT),
+        {
+          providedCodeActionKinds: RemoveJsonPropertyDiagnosticCodeActionProvider.providedCodeActionKinds
         }
       ),
 

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateLinter/layout.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateLinter/layout.test.ts
@@ -198,4 +198,47 @@ describe('TemplateLinterManager lints layout.json', () => {
       );
     });
   });
+
+  it('shows problems on unnecessary navigation objects', async () => {
+    const layoutJson = {
+      pages: [
+        {
+          title: 'Page1',
+          layout: {
+            type: 'SingleColumn',
+            right: {
+              items: [{ type: 'Text', text: 'text' }]
+            }
+          },
+          navigation: {} // This should get a warning since there is no `navigationPanel`
+        }
+      ],
+      appDetails: {
+        navigation: {} // Ditto
+      }
+    };
+    const [layoutEditor] = await createTemplateWithRelatedFiles({
+      field: 'layoutDefinition',
+      path: 'layout.json',
+      initialJson: layoutJson
+    });
+
+    let diagnostics = (
+      await waitForDiagnostics(layoutEditor.document.uri, undefined, 'Navigation object warnings')
+    ).sort(sortDiagnostics);
+    if (diagnostics.length !== 2) {
+      expect.fail('Expected 2 diagnostics, got:\n' + JSON.stringify(diagnostics, undefined, 2));
+    }
+    expect(diagnostics[0], 'diagnostics[0]').to.be.not.undefined;
+    expect(diagnostics[0].message, 'diagnostics[0].message').to.equal(
+      'navigation has no effect unless a navigationPanel is defined as part of the layout.'
+    );
+    expect(diagnostics[0].code, 'diagnostics[0].message').to.equal(ERRORS.LAYOUT_PAGE_UNNECESSARY_NAVIGATION_OBJECT);
+
+    expect(diagnostics[1], 'diagnostics[1]').to.be.not.undefined;
+    expect(diagnostics[1].message, 'diagnostics[1].message').to.equal(
+      'navigation has no effect unless a navigationPanel is defined as part of the layout.'
+    );
+    expect(diagnostics[1].code, 'diagnostics[1].message').to.equal(ERRORS.LAYOUT_PAGE_UNNECESSARY_NAVIGATION_OBJECT);
+  });
 });

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateLinter/layout.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateLinter/layout.test.ts
@@ -223,7 +223,7 @@ describe('TemplateLinterManager lints layout.json', () => {
       initialJson: layoutJson
     });
 
-    let diagnostics = (
+    const diagnostics = (
       await waitForDiagnostics(layoutEditor.document.uri, undefined, 'Navigation object warnings')
     ).sort(sortDiagnostics);
     if (diagnostics.length !== 2) {

--- a/packages/analyticsdx-template-lint/src/constants.ts
+++ b/packages/analyticsdx-template-lint/src/constants.ts
@@ -180,6 +180,8 @@ export const ERRORS = Object.freeze({
   LAYOUT_TILES_EMPTY_ENUMS_VARAIBLE: 'lay-4',
   /** A tile name doesn't point to one of the variable's enums value. */
   LAYOUT_INVALID_TILE_NAME: 'lay-5',
+  /** Unsupported variable type in layout page */
+  LAYOUT_PAGE_UNNECESSARY_NAVIGATION_OBJECT: 'lay-6',
 
   /** ApexCallback readiness definition but template has no apexCallback */
   READINESS_NO_APEX_CALLBACK: 'read-1',

--- a/packages/analyticsdx-template-lint/src/linter.ts
+++ b/packages/analyticsdx-template-lint/src/linter.ts
@@ -1203,7 +1203,8 @@ export abstract class TemplateLinter<
           doc,
           'navigation has no effect unless a navigationPanel is defined as part of the layout.',
           ERRORS.LAYOUT_PAGE_UNNECESSARY_NAVIGATION_OBJECT,
-          node
+          node,
+          { severity: TemplateLinterDiagnosticSeverity.Information }
         );
       };
       matchJsonNodesAtPattern(layoutJson, ['pages', '*', 'navigation'], addDiagnosticForUnnecessaryNavigationObject);

--- a/packages/analyticsdx-template-lint/src/linter.ts
+++ b/packages/analyticsdx-template-lint/src/linter.ts
@@ -1091,13 +1091,14 @@ export abstract class TemplateLinter<
   private async lintLayout(templateInfo: JsonNode) {
     const { doc, json: layout } = await this.loadTemplateRelPathJson(templateInfo, ['layoutDefinition']);
     if (doc && layout) {
-      // start this one
-      const p = this.lintLayoutCheckVariables(templateInfo, doc, layout);
-      return p;
+      await Promise.all([
+        this.lintLayoutCheckVariables(templateInfo, doc, layout),
+        this.lintLayoutCheckNavigationObjects(doc, layout)
+      ]);
     }
   }
 
-  private async lintLayoutCheckVariables(templateInfo: JsonNode, doc: Document, layoutJson: JsonNode) {
+  private async lintLayoutCheckVariables(templateInfo: JsonNode, doc: Document, layoutJson: JsonNode): Promise<void> {
     const { doc: variablesDoc, variableTypes } = await this.loadVariableTypesForTemplate(templateInfo);
     // go through the variables items in the pages' layouts
     const variables = findAllVariableNamesForLayoutDefinition(layoutJson);
@@ -1188,6 +1189,25 @@ export abstract class TemplateLinter<
           }
         }
       });
+    }
+  }
+
+  private async lintLayoutCheckNavigationObjects(doc: Document, layoutJson: JsonNode): Promise<void> {
+    // Check to see if there is a navigationPanel object
+    const navigationPanelNode = matchJsonNodeAtPattern(layoutJson, ['navigationPanel']);
+    if (!navigationPanelNode) {
+      // If there is no navigationPanel defined, make sure there are no
+      // navigation objects defined on pages because they will have no effect.
+      const addDiagnosticForUnnecessaryNavigationObject = (node: JsonNode) => {
+        this.addDiagnostic(
+          doc,
+          'navigation has no effect unless a navigationPanel is defined as part of the layout.',
+          ERRORS.LAYOUT_PAGE_UNNECESSARY_NAVIGATION_OBJECT,
+          node
+        );
+      };
+      matchJsonNodesAtPattern(layoutJson, ['pages', '*', 'navigation'], addDiagnosticForUnnecessaryNavigationObject);
+      matchJsonNodesAtPattern(layoutJson, ['appDetails', 'navigation'], addDiagnosticForUnnecessaryNavigationObject);
     }
   }
 

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -181,6 +181,10 @@
                 }
               }
             ]
+          },
+          "navigation": {
+            "$ref": "#/definitions/navigation",
+            "description": "Configure the node in the navigation panel for this page."
           }
         },
         "defaultSnippets": [
@@ -271,6 +275,36 @@
           ]
         }
       ]
+    },
+    "navigationPanel": {
+      "type": "object",
+      "description": "Controls whether the navigation panel appears and its title.",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "The title to be displayed at the top of the navigation panel."
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "New navigation panel",
+          "body": {
+            "title": "$0"
+          }
+        }
+      ]
+    },
+    "appDetails": {
+      "type": "object",
+      "description": "Configuration for the app details page.",
+      "additionalProperties": false,
+      "properties": {
+        "navigation": {
+          "$ref": "#/definitions/navigation",
+          "description": "Configure the app details page node in the navigation panel."
+        }
+      }
     }
   },
   "definitions": {
@@ -626,6 +660,28 @@
         }
       },
       "required": ["type", "image"]
+    },
+    "navigation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "parentLabel": {
+          "type": "string",
+          "description": "Nest this node in the navigation panel under a parent node with this label."
+        },
+        "label": {
+          "type": "string",
+          "description": "Override the label for this node in the navigation panel."
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "New navigation",
+          "body": {
+            "label": "${1:Label override}"
+          }
+        }
+      ]
     }
   }
 }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidLayoutJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidLayoutJsonTests.ts
@@ -76,4 +76,22 @@ describe('layout-schema.json finds errors in', () => {
     errors.expectInvalidProps(true, 'displayMessages');
     errors.expectNoUnrecognizedErrors();
   });
+
+  it('invalid-appDetails.json', async () => {
+    const errors = await validate('invalid-appDetails.json');
+    errors.expectInvalidProps(true, 'appDetails.unknownProperty');
+    errors.expectNoUnrecognizedErrors();
+  });
+
+  it('invalid-navigationPanel.json', async () => {
+    const errors = await validate('invalid-navigationPanel.json');
+    errors.expectInvalidProps(true, 'navigationPanel.unknownProperty');
+    errors.expectNoUnrecognizedErrors();
+  });
+
+  it('invalid-navigation.json', async () => {
+    const errors = await validate('invalid-navigation.json');
+    errors.expectInvalidProps(true, 'pages[0].navigation.unknownProperty', 'appDetails.navigation.unknownProperty');
+    errors.expectNoUnrecognizedErrors();
+  });
 });

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-appDetails.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-appDetails.json
@@ -1,0 +1,5 @@
+{
+  "appDetails": {
+    "unknownProperty": "This should trigger a warning"
+  }
+}

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-navigation.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-navigation.json
@@ -1,0 +1,26 @@
+{
+  "pages": [
+    {
+      "title": "test title",
+      "layout": {
+        "type": "SingleColumn",
+        "center": {
+          "items": [
+            {
+              "type": "Text",
+              "text": "test text"
+            }
+          ]
+        }
+      },
+      "navigation": {
+        "unknownProperty": "This should trigger a warning"
+      }
+    }
+  ],
+  "appDetails": {
+    "navigation": {
+      "unknownProperty": "This should trigger a warning"
+    }
+  }
+}

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-navigationPanel.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-navigationPanel.json
@@ -1,0 +1,5 @@
+{
+  "navigationPanel": {
+    "unknownProperty": "This should trigger a warning"
+  }
+}

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
@@ -8,6 +8,10 @@
       "condition": "{{true}}",
       "title": "Primitive Array Variables",
       "helpUrl": "https://salesforce.com/",
+      "navigation": {
+        "label": "test label",
+        "parentLabel": "test parent label"
+      },
       "layout": {
         "type": "SingleColumn",
         "header": {
@@ -188,5 +192,14 @@
       "text": "display message",
       "location": "AppLandingPage"
     }
-  ]
+  ],
+  "navigationPanel": {
+    "title": "Navigation Panel title"
+  },
+  "appDetails": {
+    "navigation": {
+      "label": "test label",
+      "parentLabel": "test parent label"
+    }
+  }
 }


### PR DESCRIPTION
### What does this PR do?

* Adds support for the new `navigationPanel` and `appDetails` root objects to the template layout schema.
* Similarly adds support for the `navigation` object on the `page` and `appDetails` objects.
* Adds a lint rule to tag `navigation` objects with an error if there is no `navigationPanel` defined in the layout. This isn't strictly necessary, but the `navigation` objects have no effect if there is no `navigationPanel` defined so it seemed like a good idea to me.

These are all only available in Winter '24 release.

### What issues does this PR fix or reference?

@W-13915510@
