### PR TITLE
Guidance panel in layout.json

### DIFF
--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/schemas/layoutSchema.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/schemas/layoutSchema.test.ts
@@ -74,6 +74,7 @@ describe('layout-schema.json hookup', () => {
       { type: 'Variable', expected: ['name'] },
       { type: 'Image', expected: ['image'] },
       { type: 'Text', expected: ['text'] },
+      { type: 'LinkBox', expected: ['text', 'url', 'title', 'icon'] },
       { type: 'GroupBox', expected: ['text', 'description', 'items'] }
     ].forEach(({ type, expected }) => {
       it(type, async () => {

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/schemas/layoutSchema.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/schemas/layoutSchema.test.ts
@@ -86,9 +86,9 @@ describe('layout-schema.json hookup', () => {
         );
         await waitForDiagnostics(
           layoutEditor.document.uri,
-          // there should be the 'error' error and one about the missing item field
+          // there should be the 'error' error and one about the missing required item field/property
           d => d && d.length >= 2,
-          'initial errors on layout.json'
+          'initial errors on layout.json. There should be at least two diagnotics found.'
         );
 
         const tree = parseTree(layoutEditor.document.getText());
@@ -141,9 +141,9 @@ describe('layout-schema.json hookup', () => {
         );
         await waitForDiagnostics(
           layoutEditor.document.uri,
-          // there should be the 'error' error and one about the missing item field
+          // there should be the 'error' error and one about the missing required item field/property
           d => d && d.length >= 2,
-          'initial errors on layout.json'
+          'initial errors on layout.json. There should be at least two diagnotics found.'
         );
 
         const tree = parseTree(layoutEditor.document.getText());

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
@@ -89,7 +89,7 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
     // this should be right the opening '{'
     position = doc.positionAt(node!.offset).translate({ characterDelta: 1 });
     // make sure it has the fields from the schema that aren't in the document
-    await verifyCompletionsContain(doc, position, 'condition', 'helpUrl', 'backgroundImage');
+    await verifyCompletionsContain(doc, position, 'condition', 'helpUrl', 'backgroundImage', 'guidancePanel');
 
     // find the start of the first page layout
     node = findNodeAtLocation(tree!, ['pages', 0, 'layout']);
@@ -99,21 +99,13 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
     // make sure it has the fields from the schema that aren't in the document
     await verifyCompletionsContain(doc, position, 'header');
 
-    // find the start of the first page guidance panel
-    node = findNodeAtLocation(tree!, ['pages', 0, 'guidancePanel']);
-    expect(node, 'pages[0].guidancePanel').to.not.be.undefined;
+    // find the start of the second page guidance panel
+    node = findNodeAtLocation(tree!, ['pages', 1, 'guidancePanel']);
+    expect(node, 'pages[1].guidancePanel').to.not.be.undefined;
     // this should be right the opening '{'
     position = doc.positionAt(node!.offset).translate({ characterDelta: 1 });
     // make sure it has the fields from the schema that aren't in the document
     await verifyCompletionsContain(doc, position, 'backgroundImage');
-
-    // find the start of the second page
-    node = findNodeAtLocation(tree!, ['pages', 1]);
-    expect(node, 'pages').to.not.be.undefined;
-    // this should be right the opening '{'
-    position = doc.positionAt(node!.offset).translate({ characterDelta: 1 });
-    // make sure it has the fields from the schema that aren't in the document
-    await verifyCompletionsContain(doc, position, 'condition', 'helpUrl', 'backgroundImage', 'guidancePanel');
   });
 
   it('json-schema defaultSnippets', async () => {
@@ -182,9 +174,9 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
     position = scan.end.translate({ characterDelta: 1 });
     await verifyCompletionsContain(doc, position, 'New displayMessage');
 
-    // go to just before the { in "guidancePanel"
-    node = findNodeAtLocation(tree!, ['pages', 0, 'guidancePanel']);
-    expect(node, 'pages[0].guidancePanel').to.not.be.undefined;
+    // go to just before the { in "guidancePanel" on page 2
+    node = findNodeAtLocation(tree!, ['pages', 1, 'guidancePanel']);
+    expect(node, 'pages[1].guidancePanel').to.not.be.undefined;
     scan = scanLinesUntil(doc, ch => ch === '{', doc.positionAt(node!.offset));
     if (scan.ch !== '{') {
       expect.fail("Expected to find '{' after '\"guidancePanel\":'");
@@ -193,8 +185,8 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
     await verifyCompletionsContain(doc, position, 'New guidance panel');
 
     // go to just after the [ in "guidancePanel.items"
-    node = findNodeAtLocation(tree!, ['pages', 0, 'guidancePanel', 'items']);
-    expect(node, 'pages[0].guidancePanel.items').to.not.be.undefined;
+    node = findNodeAtLocation(tree!, ['pages', 1, 'guidancePanel', 'items']);
+    expect(node, 'pages[1].guidancePanel.items').to.not.be.undefined;
     scan = scanLinesUntil(doc, ch => ch === '[', doc.positionAt(node!.offset));
     if (scan.ch !== '[') {
       expect.fail("Expected to find '[' after '\"items\":'");
@@ -204,7 +196,7 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
 
     //  go to just before the { in "guidancePanel.backgroundImage" on page 3
     node = findNodeAtLocation(tree!, ['pages', 2, 'guidancePanel', 'backgroundImage']);
-    expect(node, 'pages[0].guidancePanel.backgroundImage').to.not.be.undefined;
+    expect(node, 'pages[2].guidancePanel.backgroundImage').to.not.be.undefined;
     scan = scanLinesUntil(doc, ch => ch === '{', doc.positionAt(node!.offset));
     if (scan.ch !== '{') {
       expect.fail("Expected to find '{' after '\"pages[2].guidancePanel.backgroundImage\":'");

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
@@ -159,7 +159,8 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
       'New Image item',
       'New Text item',
       'New Variable item',
-      'New Groupbox item'
+      'New GroupBox item',
+      'New LinkBox item'
     );
 
     // go to just after the [ in items[3] (a GroupBox item type) "items"
@@ -170,7 +171,14 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
       expect.fail("Expected to find '[' after '\"items[3].items\":'");
     }
     position = scan.end.translate({ characterDelta: 1 });
-    await verifyCompletionsContain(doc, position, 'New Image item', 'New Text item', 'New Variable item');
+    await verifyCompletionsContain(
+      doc,
+      position,
+      'New Image item',
+      'New Text item',
+      'New Variable item',
+      'New LinkBox item'
+    );
 
     // go right after the [ in "displayMessages"
     node = findNodeAtLocation(tree!, ['displayMessages']);
@@ -210,7 +218,7 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
       expect.fail("Expected to find '{' after '\"pages[2].guidancePanel.backgroundImage\":'");
     }
     position = scan.end.translate({ characterDelta: -1 });
-    await verifyCompletionsContain(doc, position, 'New background image');
+    await verifyCompletionsContain(doc, position, 'New background image', 'null');
   });
 
   it('on change of path value', async () => {

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
@@ -98,6 +98,22 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
     position = doc.positionAt(node!.offset).translate({ characterDelta: 1 });
     // make sure it has the fields from the schema that aren't in the document
     await verifyCompletionsContain(doc, position, 'header');
+
+    // find the start of the first page guidance panel
+    node = findNodeAtLocation(tree!, ['pages', 0, 'guidancePanel']);
+    expect(node, 'pages[0].guidancePanel').to.not.be.undefined;
+    // this should be right the opening '{'
+    position = doc.positionAt(node!.offset).translate({ characterDelta: 1 });
+    // make sure it has the fields from the schema that aren't in the document
+    await verifyCompletionsContain(doc, position, 'backgroundImage');
+
+    // find the start of the second page
+    node = findNodeAtLocation(tree!, ['pages', 1]);
+    expect(node, 'pages').to.not.be.undefined;
+    // this should be right the opening '{'
+    position = doc.positionAt(node!.offset).translate({ characterDelta: 1 });
+    // make sure it has the fields from the schema that aren't in the document
+    await verifyCompletionsContain(doc, position, 'condition', 'helpUrl', 'backgroundImage', 'guidancePanel');
   });
 
   it('json-schema defaultSnippets', async () => {
@@ -165,6 +181,36 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
     }
     position = scan.end.translate({ characterDelta: 1 });
     await verifyCompletionsContain(doc, position, 'New displayMessage');
+
+    // go to just before the { in "guidancePanel"
+    node = findNodeAtLocation(tree!, ['pages', 0, 'guidancePanel']);
+    expect(node, 'pages[0].guidancePanel').to.not.be.undefined;
+    scan = scanLinesUntil(doc, ch => ch === '{', doc.positionAt(node!.offset));
+    if (scan.ch !== '{') {
+      expect.fail("Expected to find '{' after '\"guidancePanel\":'");
+    }
+    position = scan.end.translate({ characterDelta: -1 });
+    await verifyCompletionsContain(doc, position, 'New guidance panel');
+
+    // go to just after the [ in "guidancePanel.items"
+    node = findNodeAtLocation(tree!, ['pages', 0, 'guidancePanel', 'items']);
+    expect(node, 'pages[0].guidancePanel.items').to.not.be.undefined;
+    scan = scanLinesUntil(doc, ch => ch === '[', doc.positionAt(node!.offset));
+    if (scan.ch !== '[') {
+      expect.fail("Expected to find '[' after '\"items\":'");
+    }
+    position = scan.end.translate({ characterDelta: 1 });
+    await verifyCompletionsContain(doc, position, 'New Image item', 'New Text item', 'New LinkBox item');
+
+    //  go to just before the { in "guidancePanel.backgroundImage" on page 3
+    node = findNodeAtLocation(tree!, ['pages', 2, 'guidancePanel', 'backgroundImage']);
+    expect(node, 'pages[0].guidancePanel.backgroundImage').to.not.be.undefined;
+    scan = scanLinesUntil(doc, ch => ch === '{', doc.positionAt(node!.offset));
+    if (scan.ch !== '{') {
+      expect.fail("Expected to find '{' after '\"pages[2].guidancePanel.backgroundImage\":'");
+    }
+    position = scan.end.translate({ characterDelta: -1 });
+    await verifyCompletionsContain(doc, position, 'New background image');
   });
 
   it('on change of path value', async () => {

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
@@ -106,6 +106,14 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
     position = doc.positionAt(node!.offset).translate({ characterDelta: 1 });
     // make sure it has the fields from the schema that aren't in the document
     await verifyCompletionsContain(doc, position, 'backgroundImage');
+
+    // find the start of the app details page
+    node = findNodeAtLocation(tree!, ['appDetails']);
+    expect(node, 'appDetails').to.not.be.undefined;
+    // this should be right the opening '{'
+    position = doc.positionAt(node!.offset).translate({ characterDelta: 1 });
+    // make sure it has the fields from the schema that aren't in the document
+    await verifyCompletionsContain(doc, position, 'guidancePanel', 'navigation');
   });
 
   it('json-schema defaultSnippets', async () => {

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -186,207 +186,7 @@
             "$ref": "#/definitions/navigation",
             "description": "Configure the node in the navigation panel for this page."
           },
-          "guidancePanel": {
-            "type": "object",
-            "description": "The guidance panel specification for the page",
-            "additionalProperties": false,
-            "required": ["title"],
-            "properties": {
-              "title": {
-                "type": "string",
-                "description": "Guidance panel title",
-                "doNotSuggest": false
-              },
-              "backgroundImage": {
-                "type": "object",
-                "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel",
-                "additionalProperties": false,
-                "doNotSuggest": false,
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The image name."
-                  },
-                  "namespace": {
-                    "type": ["null", "string"],
-                    "description": "The image namespace.",
-                    "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
-                  }
-                },
-                "defaultSnippets": [
-                  {
-                    "label": "New background image",
-                    "body": {
-                      "name": "${1:name}"
-                    }
-                  }
-                ]
-              },
-              "items": {
-                "type": "array",
-                "description": "The set of the items to display in this guidance panel.",
-                "minItems": 0,
-                "items": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": ["type"],
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "description": "The item type.",
-                      "enum": ["Text", "Image", "LinkBox"],
-                      "enumDescriptions": ["Displays text.", "Displays an image.", "Displays a link item."]
-                    },
-                    "text": {
-                      "doNotSuggest": true
-                    },
-                    "variant": {
-                      "doNotSuggest": true
-                    },
-                    "image": {
-                      "doNotSuggest": true
-                    },
-                    "title": {
-                      "doNotSuggest": true
-                    },
-                    "icon": {
-                      "doNotSuggest": true
-                    },
-                    "url": {
-                      "doNotSuggest": true
-                    }
-                  },
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "required": ["type", "text"],
-                      "doNotSuggest": false,
-                      "additionalProperties": false,
-                      "properties": {
-                        "type": { "const": "Text" },
-                        "text": {
-                          "type": "string",
-                          "description": "The text to display in this item.",
-                          "doNotSuggest": false
-                        },
-                        "variant": {
-                          "type": "string",
-                          "description": "The text variant to display",
-                          "doNotSuggest": false,
-                          "enum": ["SubHeader"],
-                          "enumDescriptions": ["Text is displayed in bolded sub-header format."]
-                        }
-                      }
-                    },
-                    {
-                      "type": "object",
-                      "required": ["type", "image"],
-                      "doNotSuggest": false,
-                      "additionalProperties": false,
-                      "properties": {
-                        "type": { "const": "Image" },
-                        "image": {
-                          "type": "object",
-                          "description": "The image to display in this item.",
-                          "doNotSuggest": false,
-                          "additionalProperties": false,
-                          "required": ["name"],
-                          "properties": {
-                            "namespace": {
-                              "type": ["null", "string"],
-                              "description": "The image namespace.",
-                              "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "The image name."
-                            }
-                          },
-                          "defaultSnippets": [
-                            {
-                              "label": "New image",
-                              "body": {
-                                "name": "${1:name}"
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "type": "object",
-                      "required": ["type", "text", "url"],
-                      "doNotSuggest": false,
-                      "additionalProperties": false,
-                      "properties": {
-                        "type": { "const": "LinkBox" },
-                        "text": {
-                          "type": "string",
-                          "description": "The text to display for the link.",
-                          "doNotSuggest": false
-                        },
-                        "icon": {
-                          "type": "string",
-                          "description": "The icon to display in this linkBox.",
-                          "doNotSuggest": false
-                        },
-                        "title": {
-                          "type": "string",
-                          "description": "The title to display in this linkBox.",
-                          "doNotSuggest": false
-                        },
-                        "url": {
-                          "type": "string",
-                          "description": "The link url.",
-                          "doNotSuggest": false
-                        }
-                      }
-                    }
-                  ],
-                  "defaultSnippets": [
-                    {
-                      "label": "New Text item",
-                      "body": {
-                        "type": "Text",
-                        "text": "${1}"
-                      }
-                    },
-                    {
-                      "label": "New Image item",
-                      "body": {
-                        "type": "Image",
-                        "image": {
-                          "name": "${1}"
-                        }
-                      }
-                    },
-                    {
-                      "label": "New LinkBox item",
-                      "body": {
-                        "type": "LinkBox",
-                        "text": "${1}",
-                        "url": "${2}",
-                        "icon": "${3}",
-                        "title": "${4}"
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "defaultSnippets": [
-              {
-                "label": "New guidance panel",
-                "body": {
-                  "title": "${1}",
-                  "backgroundImage": {
-                    "name": "${2}"
-                  },
-                  "items": []
-                }
-              }
-            ]
-          }
+          "guidancePanel": { "$ref": "#/definitions/guidancePanel" }
         },
         "defaultSnippets": [
           {
@@ -880,6 +680,173 @@
           "label": "New navigation",
           "body": {
             "label": "${1:Label override}"
+          }
+        }
+      ]
+    },
+    "guidancePanel": {
+      "type": "object",
+      "description": "The guidance panel specification for the page",
+      "additionalProperties": false,
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Guidance panel title",
+          "doNotSuggest": false
+        },
+        "backgroundImage": {
+          "type": "object",
+          "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel",
+          "additionalProperties": false,
+          "doNotSuggest": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The image name."
+            },
+            "namespace": {
+              "type": ["null", "string"],
+              "description": "The image namespace.",
+              "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
+            }
+          },
+          "defaultSnippets": [
+            {
+              "label": "New background image",
+              "body": {
+                "name": "${1:name}"
+              }
+            }
+          ]
+        },
+        "items": {
+          "type": "array",
+          "description": "The set of the items to display in this guidance panel.",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "The item type.",
+                "enum": ["Text", "Image", "LinkBox"],
+                "enumDescriptions": ["Displays text.", "Displays an image.", "Displays a link item."]
+              },
+              "text": {
+                "doNotSuggest": true
+              },
+              "variant": {
+                "doNotSuggest": true
+              },
+              "image": {
+                "doNotSuggest": true
+              },
+              "title": {
+                "doNotSuggest": true
+              },
+              "icon": {
+                "doNotSuggest": true
+              },
+              "url": {
+                "doNotSuggest": true
+              }
+            },
+            "anyOf": [
+              {
+                "type": "object",
+                "required": ["type", "text"],
+                "doNotSuggest": false,
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "const": "Text" },
+                  "text": {
+                    "type": "string",
+                    "description": "The text to display in this item.",
+                    "doNotSuggest": false
+                  },
+                  "variant": {
+                    "type": "string",
+                    "description": "The text variant to display",
+                    "doNotSuggest": false,
+                    "enum": ["SubHeader"],
+                    "enumDescriptions": ["Text is displayed in bolded sub-header format."]
+                  }
+                }
+              },
+              { "$ref": "#/definitions/imageItem" },
+              {
+                "type": "object",
+                "required": ["type", "text", "url"],
+                "doNotSuggest": false,
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "const": "LinkBox" },
+                  "text": {
+                    "type": "string",
+                    "description": "The text to display for the link.",
+                    "doNotSuggest": false
+                  },
+                  "icon": {
+                    "type": "string",
+                    "description": "The icon to display in this linkBox.",
+                    "doNotSuggest": false
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "The title to display in this linkBox.",
+                    "doNotSuggest": false
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The link url.",
+                    "doNotSuggest": false
+                  }
+                }
+              }
+            ],
+            "defaultSnippets": [
+              {
+                "label": "New Text item",
+                "body": {
+                  "type": "Text",
+                  "text": "${1}"
+                }
+              },
+              {
+                "label": "New Image item",
+                "body": {
+                  "type": "Image",
+                  "image": {
+                    "name": "${1}"
+                  }
+                }
+              },
+              {
+                "label": "New LinkBox item",
+                "body": {
+                  "type": "LinkBox",
+                  "text": "${1}",
+                  "url": "${2}",
+                  "icon": "${3}",
+                  "title": "${4}"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "New guidance panel",
+          "body": {
+            "title": "${1}",
+            "backgroundImage": {
+              "name": "${2}"
+            },
+            "items": []
           }
         }
       ]

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -686,7 +686,7 @@
     },
     "guidancePanel": {
       "type": "object",
-      "description": "The guidance panel specification for the page",
+      "description": "The guidance panel specification for the page.",
       "additionalProperties": false,
       "required": ["title"],
       "properties": {
@@ -697,7 +697,7 @@
         },
         "backgroundImage": {
           "type": "object",
-          "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel",
+          "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel.",
           "additionalProperties": false,
           "doNotSuggest": false,
           "properties": {
@@ -769,7 +769,7 @@
                   },
                   "variant": {
                     "type": "string",
-                    "description": "The text variant to display",
+                    "description": "The text variant to display.",
                     "doNotSuggest": false,
                     "enum": ["SubHeader"],
                     "enumDescriptions": ["Text is displayed in bolded sub-header format."]
@@ -791,12 +791,12 @@
                   },
                   "icon": {
                     "type": "string",
-                    "description": "The icon to display in this linkBox.",
+                    "description": "The icon to display in this LinkBox.",
                     "doNotSuggest": false
                   },
                   "title": {
                     "type": "string",
-                    "description": "The title to display in this linkBox.",
+                    "description": "The title to display in this LinkBox.",
                     "doNotSuggest": false
                   },
                   "url": {

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -190,22 +190,27 @@
             "type": "object",
             "description": "The guidance panel specification for the page",
             "additionalProperties": false,
+            "required": ["title"],
             "properties": {
               "title": {
                 "type": "string",
                 "description": "Guidance panel title",
                 "doNotSuggest": false
               },
-              "background": {
+              "backgroundImage": {
                 "type": "object",
                 "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel",
                 "additionalProperties": false,
                 "doNotSuggest": false,
-                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string",
                     "description": "The image name."
+                  },
+                  "namespace": {
+                    "type": ["null", "string"],
+                    "description": "The image namespace.",
+                    "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
                   }
                 },
                 "defaultSnippets": [
@@ -233,6 +238,9 @@
                       "enumDescriptions": ["Displays text.", "Displays an image.", "Displays a link item."]
                     },
                     "text": {
+                      "doNotSuggest": true
+                    },
+                    "variant": {
                       "doNotSuggest": true
                     },
                     "image": {
@@ -263,8 +271,10 @@
                         },
                         "variant": {
                           "type": "string",
-                          "description": "The bolded sub-header text to display in this item.",
-                          "doNotSuggest": false
+                          "description": "The text variant to display",
+                          "doNotSuggest": false,
+                          "enum": ["SubHeader"],
+                          "enumDescriptions": ["Text is displayed in bolded sub-header format."]
                         }
                       }
                     },
@@ -369,7 +379,7 @@
                 "label": "New guidance panel",
                 "body": {
                   "title": "${1}",
-                  "background": {
+                  "backgroundImage": {
                     "name": "${2}"
                   },
                   "items": []

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -781,7 +781,7 @@
         },
         "backgroundImage": {
           "$ref": "#/definitions/backgroundImage",
-          "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel."
+          "description": "Image to display in the background of this guidance panel. It should be a vertical image and it will be fixed at the bottom of the guidance panel."
         },
         "items": {
           "type": "array",

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -478,7 +478,7 @@
                 "required": ["type", "items"]
               },
               {
-                "properties": { "type": { "not": { "enum": ["Variable", "Text", "Image", "GroupBox"] } } }
+                "properties": { "type": { "not": { "enum": ["Variable", "Text", "Image", "GroupBox", "LinkBox"] } } }
               }
             ],
             "defaultSnippets": [

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -43,29 +43,9 @@
             "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
           },
           "backgroundImage": {
-            "type": ["null", "object"],
-            "description": "Image to display in the background of this page. It should be a horizontal image and it will be fixed at the bottom of the page",
-            "additionalProperties": false,
-            "required": ["name"],
-            "properties": {
-              "namespace": {
-                "type": ["null", "string"],
-                "description": "The image namespace.",
-                "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
-              },
-              "name": {
-                "type": "string",
-                "description": "The image name."
-              }
-            },
-            "defaultSnippets": [
-              {
-                "label": "New backgroundImage",
-                "body": {
-                  "name": "${1:name}"
-                }
-              }
-            ]
+            "$ref": "#/definitions/backgroundImage",
+            "description": "Image to display in the background of this page. It should be a horizontal image and it will be fixed at the bottom of the page.",
+            "required": ["name"]
           },
           "layout": {
             "type": "object",
@@ -186,7 +166,10 @@
             "$ref": "#/definitions/navigation",
             "description": "Configure the node in the navigation panel for this page."
           },
-          "guidancePanel": { "$ref": "#/definitions/guidancePanel" }
+          "guidancePanel": {
+            "$ref": "#/definitions/guidancePanel",
+            "description": "The guidance panel specification for this page."
+          }
         },
         "defaultSnippets": [
           {
@@ -304,6 +287,10 @@
         "navigation": {
           "$ref": "#/definitions/navigation",
           "description": "Configure the app details page node in the navigation panel."
+        },
+        "guidancePanel": {
+          "$ref": "#/definitions/guidancePanel",
+          "description": "The guidance panel specification for the app details page."
         }
       }
     }
@@ -662,6 +649,58 @@
       },
       "required": ["type", "image"]
     },
+    "backgroundImage": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "type": ["null", "string"],
+          "description": "The image namespace.",
+          "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
+        },
+        "name": {
+          "type": "string",
+          "description": "The image name."
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "New backgroundImage",
+          "body": {
+            "name": "${1:name}"
+          }
+        }
+      ]
+    },
+    "linkBoxItem": {
+      "type": "object",
+      "required": ["type", "text", "url"],
+      "doNotSuggest": false,
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "LinkBox" },
+        "text": {
+          "type": "string",
+          "description": "The text to display for the link. This can contain {{...}} expressions.",
+          "doNotSuggest": false
+        },
+        "icon": {
+          "type": "string",
+          "description": "The icon to display in this LinkBox. This can contain {{...}} expressions.",
+          "doNotSuggest": false
+        },
+        "title": {
+          "type": "string",
+          "description": "The title to display in this LinkBox. This can contain {{...}} expressions.",
+          "doNotSuggest": false
+        },
+        "url": {
+          "type": "string",
+          "description": "The link url.",
+          "doNotSuggest": false
+        }
+      }
+    },
     "navigation": {
       "type": "object",
       "additionalProperties": false,
@@ -686,39 +725,17 @@
     },
     "guidancePanel": {
       "type": "object",
-      "description": "The guidance panel specification for the page.",
       "additionalProperties": false,
       "required": ["title"],
       "properties": {
         "title": {
           "type": "string",
-          "description": "Guidance panel title",
+          "description": "Guidance panel title.",
           "doNotSuggest": false
         },
         "backgroundImage": {
-          "type": "object",
-          "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel.",
-          "additionalProperties": false,
-          "doNotSuggest": false,
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "The image name."
-            },
-            "namespace": {
-              "type": ["null", "string"],
-              "description": "The image namespace.",
-              "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
-            }
-          },
-          "defaultSnippets": [
-            {
-              "label": "New background image",
-              "body": {
-                "name": "${1:name}"
-              }
-            }
-          ]
+          "$ref": "#/definitions/backgroundImage",
+          "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel."
         },
         "items": {
           "type": "array",
@@ -764,7 +781,7 @@
                   "type": { "const": "Text" },
                   "text": {
                     "type": "string",
-                    "description": "The text to display in this item.",
+                    "description": "The text to display in this item. This can contain {{...}} expressions.",
                     "doNotSuggest": false
                   },
                   "variant": {
@@ -777,35 +794,7 @@
                 }
               },
               { "$ref": "#/definitions/imageItem" },
-              {
-                "type": "object",
-                "required": ["type", "text", "url"],
-                "doNotSuggest": false,
-                "additionalProperties": false,
-                "properties": {
-                  "type": { "const": "LinkBox" },
-                  "text": {
-                    "type": "string",
-                    "description": "The text to display for the link.",
-                    "doNotSuggest": false
-                  },
-                  "icon": {
-                    "type": "string",
-                    "description": "The icon to display in this LinkBox.",
-                    "doNotSuggest": false
-                  },
-                  "title": {
-                    "type": "string",
-                    "description": "The title to display in this LinkBox.",
-                    "doNotSuggest": false
-                  },
-                  "url": {
-                    "type": "string",
-                    "description": "The link url.",
-                    "doNotSuggest": false
-                  }
-                }
-              }
+              { "$ref": "#/definitions/linkBoxItem" }
             ],
             "defaultSnippets": [
               {

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -313,12 +313,13 @@
               "type": {
                 "type": "string",
                 "description": "The item type.",
-                "enum": ["Variable", "Text", "Image", "GroupBox"],
+                "enum": ["Variable", "Text", "Image", "GroupBox", "LinkBox"],
                 "enumDescriptions": [
                   "Displays a template variable.",
                   "Displays text.",
                   "Displays an image.",
-                  "Displays a group of items"
+                  "Displays a group of items",
+                  "Displays a link item."
                 ]
               },
               "visibility": { "$ref": "#/definitions/visibility" },
@@ -345,12 +346,22 @@
               },
               "tiles": {
                 "doNotSuggest": true
+              },
+              "title": {
+                "doNotSuggest": true
+              },
+              "icon": {
+                "doNotSuggest": true
+              },
+              "url": {
+                "doNotSuggest": true
               }
             },
             "anyOf": [
               { "$ref": "#/definitions/variableItem" },
               { "$ref": "#/definitions/textItem" },
               { "$ref": "#/definitions/imageItem" },
+              { "$ref": "#/definitions/linkBoxItem" },
               {
                 "properties": {
                   "type": { "const": "GroupBox" },
@@ -377,8 +388,13 @@
                         "type": {
                           "type": "string",
                           "description": "The item type.",
-                          "enum": ["Variable", "Text", "Image"],
-                          "enumDescriptions": ["Displays a template variable.", "Displays text.", "Displays an image."]
+                          "enum": ["Variable", "Text", "Image", "LinkBox"],
+                          "enumDescriptions": [
+                            "Displays a template variable.",
+                            "Displays text.",
+                            "Displays an image.",
+                            "Displays a link item."
+                          ]
                         },
                         "visibility": { "$ref": "#/definitions/visibility" },
                         "name": {
@@ -401,12 +417,22 @@
                         },
                         "tiles": {
                           "doNotSuggest": true
+                        },
+                        "title": {
+                          "doNotSuggest": true
+                        },
+                        "icon": {
+                          "doNotSuggest": true
+                        },
+                        "url": {
+                          "doNotSuggest": true
                         }
                       },
                       "anyOf": [
                         { "$ref": "#/definitions/variableItem" },
                         { "$ref": "#/definitions/textItem" },
-                        { "$ref": "#/definitions/imageItem" }
+                        { "$ref": "#/definitions/imageItem" },
+                        { "$ref": "#/definitions/linkBoxItem" }
                       ],
                       "defaultSnippets": [
                         {
@@ -433,6 +459,16 @@
                               "name": "${1}"
                             },
                             "visibility": "${2:Visible}"
+                          }
+                        },
+                        {
+                          "label": "New LinkBox item",
+                          "body": {
+                            "type": "LinkBox",
+                            "text": "${1}",
+                            "url": "${2}",
+                            "icon": "${3}",
+                            "title": "${4}"
                           }
                         }
                       ]
@@ -473,7 +509,7 @@
                 }
               },
               {
-                "label": "New Groupbox item",
+                "label": "New GroupBox item",
                 "body": {
                   "type": "GroupBox",
                   "text": "${1}",
@@ -486,6 +522,16 @@
                     }
                   ],
                   "visibility": "${5:Visible}"
+                }
+              },
+              {
+                "label": "New LinkBox item",
+                "body": {
+                  "type": "LinkBox",
+                  "text": "${1}",
+                  "url": "${2}",
+                  "icon": "${3}",
+                  "title": "${4}"
                 }
               }
             ]
@@ -649,29 +695,6 @@
       },
       "required": ["type", "image"]
     },
-    "backgroundImage": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "namespace": {
-          "type": ["null", "string"],
-          "description": "The image namespace.",
-          "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
-        },
-        "name": {
-          "type": "string",
-          "description": "The image name."
-        }
-      },
-      "defaultSnippets": [
-        {
-          "label": "New backgroundImage",
-          "body": {
-            "name": "${1:name}"
-          }
-        }
-      ]
-    },
     "linkBoxItem": {
       "type": "object",
       "required": ["type", "text", "url"],
@@ -700,6 +723,29 @@
           "doNotSuggest": false
         }
       }
+    },
+    "backgroundImage": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "type": ["null", "string"],
+          "description": "The image namespace.",
+          "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
+        },
+        "name": {
+          "type": "string",
+          "description": "The image name."
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "New background image",
+          "body": {
+            "name": "${1:name}"
+          }
+        }
+      ]
     },
     "navigation": {
       "type": "object",

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -185,6 +185,197 @@
           "navigation": {
             "$ref": "#/definitions/navigation",
             "description": "Configure the node in the navigation panel for this page."
+          },
+          "guidancePanel": {
+            "type": "object",
+            "description": "The guidance panel specification for the page",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Guidance panel title",
+                "doNotSuggest": false
+              },
+              "background": {
+                "type": "object",
+                "description": "Image to display in the background of this guidance panel. It should be a horizontal image and it will be fixed at the bottom of the guidance panel",
+                "additionalProperties": false,
+                "doNotSuggest": false,
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The image name."
+                  }
+                },
+                "defaultSnippets": [
+                  {
+                    "label": "New background image",
+                    "body": {
+                      "name": "${1:name}"
+                    }
+                  }
+                ]
+              },
+              "items": {
+                "type": "array",
+                "description": "The set of the items to display in this guidance panel.",
+                "minItems": 0,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "The item type.",
+                      "enum": ["Text", "Image", "LinkBox"],
+                      "enumDescriptions": ["Displays text.", "Displays an image.", "Displays a link item."]
+                    },
+                    "text": {
+                      "doNotSuggest": true
+                    },
+                    "image": {
+                      "doNotSuggest": true
+                    },
+                    "title": {
+                      "doNotSuggest": true
+                    },
+                    "icon": {
+                      "doNotSuggest": true
+                    },
+                    "url": {
+                      "doNotSuggest": true
+                    }
+                  },
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "required": ["type", "text"],
+                      "doNotSuggest": false,
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": { "const": "Text" },
+                        "text": {
+                          "type": "string",
+                          "description": "The text to display in this item.",
+                          "doNotSuggest": false
+                        },
+                        "variant": {
+                          "type": "string",
+                          "description": "The bolded sub-header text to display in this item.",
+                          "doNotSuggest": false
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": ["type", "image"],
+                      "doNotSuggest": false,
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": { "const": "Image" },
+                        "image": {
+                          "type": "object",
+                          "description": "The image to display in this item.",
+                          "doNotSuggest": false,
+                          "additionalProperties": false,
+                          "required": ["name"],
+                          "properties": {
+                            "namespace": {
+                              "type": ["null", "string"],
+                              "description": "The image namespace.",
+                              "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The image name."
+                            }
+                          },
+                          "defaultSnippets": [
+                            {
+                              "label": "New image",
+                              "body": {
+                                "name": "${1:name}"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": ["type", "text", "url"],
+                      "doNotSuggest": false,
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": { "const": "LinkBox" },
+                        "text": {
+                          "type": "string",
+                          "description": "The text to display for the link.",
+                          "doNotSuggest": false
+                        },
+                        "icon": {
+                          "type": "string",
+                          "description": "The icon to display in this linkBox.",
+                          "doNotSuggest": false
+                        },
+                        "title": {
+                          "type": "string",
+                          "description": "The title to display in this linkBox.",
+                          "doNotSuggest": false
+                        },
+                        "url": {
+                          "type": "string",
+                          "description": "The link url.",
+                          "doNotSuggest": false
+                        }
+                      }
+                    }
+                  ],
+                  "defaultSnippets": [
+                    {
+                      "label": "New Text item",
+                      "body": {
+                        "type": "Text",
+                        "text": "${1}"
+                      }
+                    },
+                    {
+                      "label": "New Image item",
+                      "body": {
+                        "type": "Image",
+                        "image": {
+                          "name": "${1}"
+                        }
+                      }
+                    },
+                    {
+                      "label": "New LinkBox item",
+                      "body": {
+                        "type": "LinkBox",
+                        "text": "${1}",
+                        "url": "${2}",
+                        "icon": "${3}",
+                        "title": "${4}"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "defaultSnippets": [
+              {
+                "label": "New guidance panel",
+                "body": {
+                  "title": "${1}",
+                  "background": {
+                    "name": "${2}"
+                  },
+                  "items": []
+                }
+              }
+            ]
           }
         },
         "defaultSnippets": [

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidLayoutJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidLayoutJsonTests.ts
@@ -28,7 +28,13 @@ describe('layout-schema.json finds errors in', () => {
       'pages[0].layout.center.items[2].items[2].name',
       'pages[0].layout.center.items[3].variant',
       'pages[1].layout.type',
-      'displayMessages[0].location'
+      'displayMessages[0].location',
+      'pages[0].guidancePanel.items[0].type',
+      'pages[0].guidancePanel.items[0].variant',
+      'pages[0].guidancePanel.items[1].type',
+      'pages[0].guidancePanel.items[1].variant',
+      'pages[0].guidancePanel.items[2].type',
+      'pages[0].guidancePanel.items[2].variant'
     );
   });
 
@@ -50,13 +56,24 @@ describe('layout-schema.json finds errors in', () => {
       'pages[0].layout.center.items[2].items[0].image.error',
       'pages[0].layout.center.items[2].items[1].tiles.bar.error',
       'pages[0].layout.center.items[3].tiles.foo.error',
-      'displayMessages[0].error'
+      'displayMessages[0].error',
+      'pages[0].guidancePanel.error',
+      'pages[0].guidancePanel.backgroundImage.error',
+      'pages[0].guidancePanel.items[0].error',
+      'pages[0].guidancePanel.items[1].image.error',
+      'pages[0].guidancePanel.items[1].error',
+      'pages[0].guidancePanel.items[2].error'
     );
   });
 
   it('invalid-pages.json', async () => {
     const errors = await validate('invalid-pages.json');
-    errors.expectInvalidProps(false, 'pages[0].layout.center.items[1].name');
+    errors.expectInvalidProps(
+      false,
+      'pages[0].layout.center.items[1].name',
+      'pages[0].guidancePanel.title',
+      'pages[0].guidancePanel.backgroundImage'
+    );
     errors.expectMissingProps(
       false,
       'pages[0].layout.center.items[0].type',
@@ -66,7 +83,13 @@ describe('layout-schema.json finds errors in', () => {
       'pages[0].layout.center.items[5].image.name',
       'pages[1].layout.center',
       'pages[2].layout.left',
-      'pages[2].layout.right'
+      'pages[2].layout.right',
+      'pages[0].guidancePanel.items[0].type',
+      'pages[0].guidancePanel.items[1].text',
+      'pages[0].guidancePanel.items[2].image',
+      'pages[0].guidancePanel.items[3].text',
+      'pages[0].guidancePanel.items[3].url',
+      'pages[0].guidancePanel.items[4].image.name'
     );
   });
 

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidLayoutJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidLayoutJsonTests.ts
@@ -62,7 +62,8 @@ describe('layout-schema.json finds errors in', () => {
       'pages[0].guidancePanel.items[0].error',
       'pages[0].guidancePanel.items[1].image.error',
       'pages[0].guidancePanel.items[1].error',
-      'pages[0].guidancePanel.items[2].error'
+      'pages[0].guidancePanel.items[2].error',
+      'appDetails.error'
     );
   });
 

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-enums.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-enums.json
@@ -40,6 +40,26 @@
             }
           ]
         }
+      },
+      "guidancePanel": {
+        "title": "Guidance Panel title",
+        "items": [
+          {
+            "type": "badValue",
+            "text": "Invalid type",
+            "variant": "badValue"
+          },
+          {
+            "type": "",
+            "text": "Invalid type",
+            "variant": "CheckboxTiles"
+          },
+          {
+            "type": "Variable",
+            "text": "Invalid type",
+            "variant": "CenteredCheckboxTiles"
+          }
+        ]
       }
     },
     {

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-fields.json
@@ -69,6 +69,33 @@
             }
           ]
         }
+      },
+      "guidancePanel": {
+        "error": "This should trigger a warning",
+        "backgroundImage": {
+          "error": "This should trigger a warning"
+        },
+        "items": [
+          {
+            "type": "Text",
+            "text": "PositivePossum",
+            "error": "This should trigger a warning"
+          },
+          {
+            "type": "Image",
+            "image": {
+              "name": "PositivePossum",
+              "error": "This should trigger a warning"
+            },
+            "error": "This should trigger a warning"
+          },
+          {
+            "type": "LinkBox",
+            "text": "PositivePossum",
+            "url": "https://salesforce.com/",
+            "error": "This should trigger a warning"
+          }
+        ]
       }
     }
   ],

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-fields.json
@@ -105,5 +105,8 @@
       "text": "display message",
       "location": "AppLandingPage"
     }
-  ]
+  ],
+  "appDetails": {
+    "error": "This should trigger a warning"
+  }
 }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-pages.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-pages.json
@@ -26,6 +26,26 @@
             }
           ]
         }
+      },
+      "guidancePanel": {
+        "title": {},
+        "backgroundImage": "bad image",
+        "items": [
+          {},
+          {
+            "type": "Text"
+          },
+          {
+            "type": "Image"
+          },
+          {
+            "type": "LinkBox"
+          },
+          {
+            "type": "Image",
+            "image": {}
+          }
+        ]
       }
     },
     {

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
@@ -88,6 +88,14 @@
                       "label": "label"
                     }
                   }
+                },
+                {
+                  "type": "Image",
+                  "image": {
+                    "name": "PositivePossum",
+                    "namespace": "ns"
+                  },
+                  "visibility": "Hidden"
                 }
               ],
               "visibility": "Visible"

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
@@ -94,6 +94,34 @@
             }
           ]
         }
+      },
+      "guidancePanel": {
+        "title": "Documentation",
+        "backgroundImage": {
+          "name": "GuidancePanelBackground",
+          "namespace": "ns"
+        },
+        "items": [
+          {
+            "type": "Text",
+            "text": "A Sub Header",
+            "variant": "SubHeader"
+          },
+          {
+            "type": "Image",
+            "image": {
+              "name": "PositivePossum",
+              "namespace": "ns"
+            }
+          },
+          {
+            "type": "LinkBox",
+            "text": "A Link",
+            "url": "https://salesforce.com",
+            "icon": "standard:knowledge",
+            "title": "Link Title"
+          }
+        ]
       }
     },
     {

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
@@ -96,9 +96,23 @@
                     "namespace": "ns"
                   },
                   "visibility": "Hidden"
+                },
+                {
+                  "type": "LinkBox",
+                  "text": "A Link",
+                  "url": "https://salesforce.com",
+                  "icon": "standard:knowledge",
+                  "title": "Link Title"
                 }
               ],
               "visibility": "Visible"
+            },
+            {
+              "type": "LinkBox",
+              "text": "A Link",
+              "url": "https://salesforce.com",
+              "icon": "standard:knowledge",
+              "title": "Link Title"
             }
           ]
         }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/empty-items.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/empty-items.json
@@ -7,6 +7,9 @@
         "center": {
           "items": []
         }
+      },
+      "guidancePanel": {
+        "title": "Guidance panel title"
       }
     },
     {
@@ -19,6 +22,10 @@
         "right": {
           "items": []
         }
+      },
+      "guidancePanel": {
+        "title": "Guidance panel title",
+        "items": []
       }
     }
   ]

--- a/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
+++ b/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
@@ -147,6 +147,53 @@
             }
           ]
         }
+      },
+      "guidancePanel": {
+        "title": "Documentation",
+        "items": [
+          {
+            "type": "Text",
+            "text": "A Sub Header",
+            "variant": "SubHeader"
+          },
+          {
+            "type": "Image",
+            "image": {
+              "name": "PositivePossum",
+              "namespace": "ns"
+            }
+          },
+          {
+            "type": "LinkBox",
+            "text": "A Link",
+            "url": "https://salesforce.com",
+            "icon": "standard:knowledge",
+            "title": "Link Title"
+          }
+        ]
+      }
+    },
+    {
+      "title": "Page 2",
+      "layout": {
+        "type": "SingleColumn",
+        "center": {
+          "items": []
+        }
+      }
+    },
+    {
+      "title": "Page 3",
+      "layout": {
+        "type": "SingleColumn",
+        "center": {
+          "items": []
+        }
+      },
+      "guidancePanel": {
+        "title": "Documentation",
+        "backgroundImage": {},
+        "items": []
       }
     }
   ],

--- a/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
+++ b/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
@@ -193,5 +193,6 @@
       "text": "",
       "location": "AppLandingPage"
     }
-  ]
+  ],
+  "appDetails": {}
 }

--- a/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
+++ b/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
@@ -174,15 +174,6 @@
       }
     },
     {
-      "title": "Page 2",
-      "layout": {
-        "type": "SingleColumn",
-        "center": {
-          "items": []
-        }
-      }
-    },
-    {
       "title": "Page 3",
       "layout": {
         "type": "SingleColumn",

--- a/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
+++ b/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
@@ -27,7 +27,14 @@
                   "type": "Image",
                   "image": { "name": "someimage" }
                 },
-                { "type": "Text", "text": "Some text here", "visibility": "{{Variables.booleanVariable}}" }
+                { "type": "Text", "text": "Some text here", "visibility": "{{Variables.booleanVariable}}" },
+                {
+                  "type": "LinkBox",
+                  "text": "A Link",
+                  "url": "https://salesforce.com",
+                  "icon": "standard:knowledge",
+                  "title": "Link Title"
+                }
               ],
               "visibility": "Visible"
             },
@@ -69,6 +76,13 @@
                   }
                 }
               ]
+            },
+            {
+              "type": "LinkBox",
+              "text": "A Link",
+              "url": "https://salesforce.com",
+              "icon": "standard:knowledge",
+              "title": "Link Title"
             }
           ]
         }


### PR DESCRIPTION
### What does this PR do?

- Add lint and editor support for GuidancePanel object in layout schema
- Add schema-based validation and tests for guidance panel properties
- Add code-completion, default snippets, and hover text on guidance panel json fields and tests
- Refactor backgroundImage to be used by regular panel and guidance panel
- Add support for linkbox item in regular panel items and groupbox items as well as tests

These are all only available in Winter '24 release.

### What issues does this PR fix or reference?
[@W-13900452](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001XneZfYAJ/view)
