### PR TITLE
@W-14003910: readiness: warn on literal null filter value if operator is not Equals nor NotEquals

### DIFF
--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -368,18 +368,12 @@
           }
         },
         "if": {
-          "properties": { "operator": { "enum": ["Equal", "NotEqual"] } },
+          "properties": {
+            "operator": { "enum": ["LessThan", "LessThanEqual", "GreaterThan", "GreaterThanEqual", "In", "NotIn"] }
+          },
           "required": ["operator"]
         },
         "then": {
-          "properties": {
-            "value": {
-              "type": ["string", "number", "null", "boolean", "array"],
-              "description": "The value to compare against. This can use ${...} expressions."
-            }
-          }
-        },
-        "else": {
           "properties": {
             "value": {
               "type": ["string", "number", "boolean", "array"],

--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -333,6 +333,7 @@
       "minItems": 0,
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "field": {
             "type": "string",
@@ -360,6 +361,10 @@
                 "pattern": "^\\$\\{.*\\}$"
               }
             ]
+          },
+          "value": {
+            "type": ["string", "number", "null", "boolean", "array"],
+            "description": "The value to compare against. This can use ${...} expressions."
           }
         },
         "if": {

--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -333,7 +333,6 @@
       "minItems": 0,
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "properties": {
           "field": {
             "type": "string",
@@ -361,10 +360,26 @@
                 "pattern": "^\\$\\{.*\\}$"
               }
             ]
-          },
-          "value": {
-            "type": ["string", "number", "null", "boolean", "array"],
-            "description": "The value to compare against. This can use ${...} expressions."
+          }
+        },
+        "if": {
+          "properties": { "operator": { "enum": ["Equal", "NotEqual"] } },
+          "required": ["operator"]
+        },
+        "then": {
+          "properties": {
+            "value": {
+              "type": ["string", "number", "null", "boolean", "array"],
+              "description": "The value to compare against. This can use ${...} expressions."
+            }
+          }
+        },
+        "else": {
+          "properties": {
+            "value": {
+              "type": ["string", "number", "boolean", "array"],
+              "description": "The value to compare against. This can use ${...} expressions."
+            }
           }
         },
         "required": ["field", "operator", "value"],

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidReadinessJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidReadinessJsonTests.ts
@@ -42,4 +42,20 @@ describe('readiness-schema.json finds errors in', () => {
       'definition.datacloud.object'
     );
   });
+
+  it('invalid-values.json', async () => {
+    const errors = await validate('invalid-values.json');
+    errors.expectInvalidProps(
+      false,
+      'templateRequirements[0].type',
+      'definition.empty.type',
+      'definition.bad.type',
+      'definition.filterOp.filters[0].value',
+      'definition.filterOp.filters[1].value',
+      'definition.filterOp.filters[2].value',
+      'definition.filterOp.filters[3].value',
+      'definition.filterOp.filters[4].value',
+      'definition.filterOp.filters[5].value'
+    );
+  });
 });

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/invalid/invalid-values.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/invalid/invalid-values.json
@@ -1,0 +1,52 @@
+{
+  "templateRequirements": [
+    {
+      "expression": "${true}",
+      "type": "error"
+    }
+  ],
+  "definition": {
+    "empty": {
+      "type": ""
+    },
+    "bad": {
+      "type": "error"
+    },
+    "filterOp": {
+      "type": "SobjectRowCount",
+      "sobject": "foo",
+      "filters": [
+        {
+          "field": "field",
+          "operator": "GreaterThan",
+          "value": null
+        },
+        {
+          "field": "field",
+          "operator": "GreaterThanEqual",
+          "value": null
+        },
+        {
+          "field": "field",
+          "operator": "LessThan",
+          "value": null
+        },
+        {
+          "field": "field",
+          "operator": "LessThanEqual",
+          "value": null
+        },
+        {
+          "field": "field",
+          "operator": "NotIn",
+          "value": null
+        },
+        {
+          "field": "field",
+          "operator": "In",
+          "value": null
+        }
+      ]
+    }
+  }
+}

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
@@ -98,7 +98,7 @@
         {
           "field": "NumberOfEmployees",
           "operator": "NotEqual",
-          "value": null
+          "value": "1"
         },
         {
           "field": "NumberOfEmployees",

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
@@ -98,7 +98,7 @@
         {
           "field": "NumberOfEmployees",
           "operator": "NotEqual",
-          "value": "1"
+          "value": null
         },
         {
           "field": "NumberOfEmployees",

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/nulls.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/nulls.json
@@ -17,6 +17,17 @@
       "type": "SobjectRowCount",
       "sobject": "Account",
       "filters": null
+    },
+    "filterOp": {
+      "type": "SobjectRowCount",
+      "sobject": "foo",
+      "filters": [
+        {
+          "field": "field",
+          "operator": "Equal",
+          "value": null
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
- Add logic to only allow null filter value for operator Equals nor NotEquals 
- Add/update tests

These are all only available in Winter '24 release.

### What issues does this PR fix or reference?
[W-14003910](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ZAJlAYAX/view)