### PR TITLE
Support valueOnError, AccessCheck in readiness files

### DIFF
--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -150,16 +150,18 @@
             "OrgDatasetRowCount",
             "AppDatasetRowCount",
             "DataCloudRowCount",
+            "ApexCallout",
             "OrgPreferenceCheck",
-            "ApexCallout"
+            "AccessCheck"
           ],
           "enumDescriptions": [
             "A check against the number of objects in the org.",
             "A check against the number of rows in a dataset in the org",
             "A check against the number of rows in a dataset that will be created by this template in the app",
             "A check against the number of Data Cloud objects in the org. Only available in Winter '24 release.",
+            "A check using a method on the template's apexCallback class.",
             "",
-            "A check using a method on the template's apexCallback class."
+            ""
           ]
         },
         "valueOnError": {},
@@ -169,7 +171,8 @@
         "dataset": { "doNotSuggest": true },
         "names": { "doNotSuggest": true },
         "method": { "doNotSuggest": true },
-        "arguments": { "doNotSuggest": true }
+        "arguments": { "doNotSuggest": true },
+        "expression": { "doNotSuggest": true }
       },
       "$comment": "Customize the type-specifc fields.",
       "anyOf": [
@@ -189,7 +192,7 @@
             },
             "valueOnError": {
               "description": "Numeric value to return instead if an error occurs at runtime.",
-              "type": ["null", "integer"],
+              "type": ["integer", "null"],
               "examples": [-1, 0]
             }
           },
@@ -211,7 +214,7 @@
             },
             "valueOnError": {
               "description": "Numeric value to return instead if an error occurs at runtime.",
-              "type": ["null", "integer"],
+              "type": ["integer", "null"],
               "examples": [-1, 0]
             }
           },
@@ -233,7 +236,7 @@
             },
             "valueOnError": {
               "description": "Numeric value to return instead if an error occurs at runtime.",
-              "type": ["null", "integer"],
+              "type": ["integer", "null"],
               "examples": [-1, 0]
             }
           },
@@ -255,7 +258,7 @@
             },
             "valueOnError": {
               "description": "Numeric value to return instead if an error occurs at runtime.",
-              "type": ["null", "integer"],
+              "type": ["integer", "null"],
               "examples": [-1, 0]
             }
           },
@@ -272,7 +275,7 @@
             },
             "valueOnError": {
               "description": "Value to return instead if an error occurs at runtime. If non-null, should be a map of name to boolean value for each pref requested.",
-              "type": ["null", "object"],
+              "type": ["object", "null"],
               "additionalProperties": {
                 "type": "boolean"
               },
@@ -307,6 +310,21 @@
         },
         {
           "properties": {
+            "type": { "const": "AccessCheck" },
+            "expression": {
+              "type": "string",
+              "minLength": 1,
+              "doNotSuggest": false
+            },
+            "valueOnError": {
+              "description": "Value to return instead if an error occurs at runtime.",
+              "type": ["boolean", "null"]
+            }
+          },
+          "required": ["type", "expression"]
+        },
+        {
+          "properties": {
             "type": {
               "not": {
                 "enum": [
@@ -315,7 +333,8 @@
                   "OrgDatasetRowCount",
                   "DataCloudRowCount",
                   "OrgPreferenceCheck",
-                  "ApexCallout"
+                  "ApexCallout",
+                  "AccessCheck"
                 ]
               }
             }

--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -59,7 +59,7 @@
               "A check against the number of objects in the org.",
               "A check against the number of rows in a dataset in the org",
               "A check against the number of rows in a dataset that will be created by this template in the app",
-              "A check against the number of Data Cloud objects in the org. Only available in Winter '24 release.",
+              "A check against the number of Data Cloud objects in the org.",
               "A check using a method on the template's apexCallback class.",
               "",
               ""
@@ -160,7 +160,7 @@
             "A check against the number of objects in the org.",
             "A check against the number of rows in a dataset in the org",
             "A check against the number of rows in a dataset that will be created by this template in the app",
-            "A check against the number of Data Cloud objects in the org. Only available in Winter '24 release.",
+            "A check against the number of Data Cloud objects in the org.",
             "A check using a method on the template's apexCallback class.",
             "",
             ""

--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -162,6 +162,7 @@
             "A check using a method on the template's apexCallback class."
           ]
         },
+        "valueOnError": {},
         "filters": { "doNotSuggest": true },
         "sobject": { "doNotSuggest": true },
         "object": { "doNotSuggest": true },
@@ -185,6 +186,11 @@
               "$ref": "#/definitions/filters",
               "description": "The query filter to use when counting the number of rows.",
               "doNotSuggest": false
+            },
+            "valueOnError": {
+              "description": "Numeric value to return instead if an error occurs at runtime.",
+              "type": ["null", "integer"],
+              "examples": [-1, 0]
             }
           },
           "required": ["type", "sobject"]
@@ -202,6 +208,11 @@
               "$ref": "#/definitions/filters",
               "description": "The query filter to use when counting the number of rows.",
               "doNotSuggest": false
+            },
+            "valueOnError": {
+              "description": "Numeric value to return instead if an error occurs at runtime.",
+              "type": ["null", "integer"],
+              "examples": [-1, 0]
             }
           },
           "required": ["type", "dataset"]
@@ -219,6 +230,11 @@
               "$ref": "#/definitions/filters",
               "description": "The query filter to use when counting the number of rows.",
               "doNotSuggest": false
+            },
+            "valueOnError": {
+              "description": "Numeric value to return instead if an error occurs at runtime.",
+              "type": ["null", "integer"],
+              "examples": [-1, 0]
             }
           },
           "required": ["type", "dataset"]
@@ -236,6 +252,11 @@
               "$ref": "#/definitions/filters",
               "description": "The query filter to use when counting the number of rows.",
               "doNotSuggest": false
+            },
+            "valueOnError": {
+              "description": "Numeric value to return instead if an error occurs at runtime.",
+              "type": ["null", "integer"],
+              "examples": [-1, 0]
             }
           },
           "required": ["type", "object"]
@@ -248,6 +269,14 @@
               "minItems": 1,
               "items": { "type": "string" },
               "doNotSuggest": false
+            },
+            "valueOnError": {
+              "description": "Value to return instead if an error occurs at runtime. If non-null, should be a map of name to boolean value for each pref requested.",
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "examples": [{}]
             }
           },
           "required": ["type", "names"]
@@ -266,6 +295,12 @@
               "description": "The values for the method arguments. The values can use ${...} expressions.",
               "additionalProperties": true,
               "doNotSuggest": false
+            },
+            "valueOnError": {
+              "description": "Value to return instead if an error occurs at runtime.",
+              "type": ["array", "boolean", "null", "number", "object", "string"],
+              "examples": [[], {}, 0],
+              "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
             }
           },
           "required": ["type", "method", "arguments"]
@@ -309,6 +344,14 @@
           "body": {
             "type": "AppDatasetRowCount",
             "dataset": "${0}",
+            "filters": []
+          }
+        },
+        {
+          "label": "New DataCloudRowCount definition",
+          "body": {
+            "type": "DataCloudRowCount",
+            "object": "${0}",
             "filters": []
           }
         },

--- a/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/readiness-schema.json
@@ -46,8 +46,9 @@
                   "OrgDatasetRowCount",
                   "AppDatasetRowCount",
                   "DataCloudRowCount",
+                  "ApexCallout",
                   "OrgPreferenceCheck",
-                  "ApexCallout"
+                  "AccessCheck"
                 ]
               },
               {
@@ -59,8 +60,9 @@
               "A check against the number of rows in a dataset in the org",
               "A check against the number of rows in a dataset that will be created by this template in the app",
               "A check against the number of Data Cloud objects in the org. Only available in Winter '24 release.",
+              "A check using a method on the template's apexCallback class.",
               "",
-              "A check using a method on the template's apexCallback class."
+              ""
             ]
           },
           "successMessage": {

--- a/packages/analyticsdx-template-lint/src/schemas/template-info-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/template-info-schema.json
@@ -274,7 +274,7 @@
     },
     "readinessDefinition": {
       "type": ["null", "string"],
-      "description": "Path to the template org readiness definition file. Only available in Summer '23 release.",
+      "description": "Path to the template org readiness definition file.",
       "defaultSnippets": [
         {
           "label": "\"\"",
@@ -304,7 +304,7 @@
     },
     "autoInstallDefinition": {
       "type": ["null", "string"],
-      "description": "Path to the auto install configuration file. Only available for app and embeddedapp template types. Available in Winter '21 release.",
+      "description": "Path to the auto install configuration file. Only available for app and embeddedapp template types.",
       "defaultSnippets": [
         {
           "label": "\"\"",
@@ -1240,7 +1240,7 @@
     },
     "onFailure": {
       "type": ["null", "object"],
-      "description": "Controls how to handle failures when processing this asset. Only available in Winter '24 release.",
+      "description": "Controls how to handle failures when processing this asset.",
       "additionalProperties": false,
       "properties": {
         "defaultStatus": {

--- a/packages/analyticsdx-template-lint/src/schemas/variables-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/variables-schema.json
@@ -83,12 +83,12 @@
             "References a list of values, controlled by the `itemsType` variable type.",
             "References true or false value.",
             "References connectors defined in the org.",
-            "References calculated insights defined in the org. Only available in Summer '23 release.",
-            "References calculated insight fields in the org. Only available in Summer '23 release.",
-            "References data lake objects in the org. Only available in Summer '23 release.",
-            "References data lake object fields in the org. Only available in Summer '23 release.",
-            "References data model objects in the org. Only available in Summer '23 release.",
-            "References data model object fields in the org. Only available in Summer '23 release.",
+            "References calculated insights defined in the org.",
+            "References calculated insight fields in the org.",
+            "References data lake objects in the org.",
+            "References data lake object fields in the org.",
+            "References data model objects in the org.",
+            "References data model object fields in the org.",
             "References fields from datasets in the org.",
             "References date fields from datasets in the org.",
             "References dimensions from dataset in the org.",
@@ -216,7 +216,7 @@
             "enumsLabels": {
               "type": ["array", "null"],
               "minItems": 0,
-              "description": "The optional display labels for the enumerated values. Only available in Summer '23 release.",
+              "description": "The optional display labels for the enumerated values.",
               "items": {
                 "type": ["string", "null"]
               },

--- a/packages/analyticsdx-template-lint/test/testutils.ts
+++ b/packages/analyticsdx-template-lint/test/testutils.ts
@@ -197,6 +197,7 @@ export class SchemaErrors {
           (error.keyword === 'const' ||
             error.keyword === 'pattern' ||
             error.keyword === 'oneOf' ||
+            error.keyword === 'anyOf' ||
             error.keyword === 'type' ||
             error.keyword === 'enum' ||
             error.keyword === 'not' ||

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidReadinessJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidReadinessJsonTests.ts
@@ -37,9 +37,15 @@ describe('readiness-schema.json finds errors in', () => {
       'definition.sobject.error',
       'definition.sobject.sobject',
       'definition.sobject.filters[0].field',
+      'definition.sobject.valueOnError',
       'definition.dataset.dataset',
+      'definition.dataset.valueOnError',
       'definition.appDataset.dataset',
-      'definition.datacloud.object'
+      'definition.appDataset.valueOnError',
+      'definition.datacloud.object',
+      'definition.datacloud.valueOnError',
+      'definition.prefs1.valueOnError',
+      'definition.prefs2.valueOnError.name'
     );
   });
 

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidReadinessJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidReadinessJsonTests.ts
@@ -45,7 +45,8 @@ describe('readiness-schema.json finds errors in', () => {
       'definition.datacloud.object',
       'definition.datacloud.valueOnError',
       'definition.prefs1.valueOnError',
-      'definition.prefs2.valueOnError.name'
+      'definition.prefs2.valueOnError.name',
+      'definition.access.valueOnError'
     );
   });
 

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/invalid/invalid-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/invalid/invalid-fields.json
@@ -57,6 +57,11 @@
       "valueOnError": {
         "name": "only booleans"
       }
+    },
+    "access": {
+      "type": "AccessCheck",
+      "expression": "foo",
+      "valueOnError": "only boolean"
     }
   }
 }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/invalid/invalid-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/invalid/invalid-fields.json
@@ -28,19 +28,35 @@
           "operator": "Equal",
           "value": ""
         }
-      ]
+      ],
+      "valueOnError": "only numbers"
     },
     "dataset": {
       "type": "OrgDatasetRowCount",
-      "dataset": ""
+      "dataset": "",
+      "valueOnError": "only numbers"
     },
     "appDataset": {
       "type": "AppDatasetRowCount",
-      "dataset": ""
+      "dataset": "",
+      "valueOnError": "only numbers"
     },
     "datacloud": {
       "type": "DataCloudRowCount",
-      "object": ""
+      "object": "",
+      "valueOnError": "only numbers"
+    },
+    "prefs1": {
+      "type": "OrgPreferenceCheck",
+      "names": ["name"],
+      "valueOnError": "only object"
+    },
+    "prefs2": {
+      "type": "OrgPreferenceCheck",
+      "names": ["name"],
+      "valueOnError": {
+        "name": "only booleans"
+      }
     }
   }
 }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
@@ -154,6 +154,11 @@
         "prefName": true,
         "prefName2": false
       }
+    },
+    "access": {
+      "type": "AccessCheck",
+      "expression": "foo",
+      "valueOnError": false
     }
   }
 }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
@@ -59,6 +59,10 @@
         "strArg": "value",
         "numArg": 100,
         "arrayArg": ["${Variables.a"]
+      },
+      "valueOnError": {
+        "foo": "bar",
+        "baz": [42]
       }
     },
     "accountCount": {
@@ -110,12 +114,14 @@
           "operator": "${Variables.op}",
           "value": "1"
         }
-      ]
+      ],
+      "valueOnError": -1
     },
     "orgDatasetCount": {
       "type": "OrgDatasetRowCount",
       "dataset": "${Variable.selectedDS.datasetId}",
-      "filters": []
+      "filters": [],
+      "valueOnError": 0
     },
     "dataCloudCount": {
       "type": "DataCloudRowCount",
@@ -126,7 +132,8 @@
           "operator": "Equal",
           "value": ""
         }
-      ]
+      ],
+      "valueOnError": 10000000
     },
     "appDatasetCount": {
       "type": "AppDatasetRowCount",
@@ -137,11 +144,16 @@
           "operator": "Equal",
           "value": "foo"
         }
-      ]
+      ],
+      "valueOnError": 42
     },
     "orgPrefs": {
       "type": "OrgPreferenceCheck",
-      "names": ["prefName", "prefName2"]
+      "names": ["prefName", "prefName2"],
+      "valueOnError": {
+        "prefName": true,
+        "prefName2": false
+      }
     }
   }
 }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/all-fields.json
@@ -49,6 +49,12 @@
       "failMessage": "${Readiness.orgPrefs.someName} Nope!",
       "successMessage": "${Readiness.orgPrefs.someName} Yep!",
       "type": "OrgPreferenceCheck"
+    },
+    {
+      "expression": "${Readiness.access}",
+      "failMessage": "${Readiness.access} Nope!",
+      "successMessage": "${Readiness.access} Yep!",
+      "type": "AccessCheck"
     }
   ],
   "definition": {

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/nulls.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/nulls.json
@@ -16,7 +16,8 @@
     "accountCheck": {
       "type": "SobjectRowCount",
       "sobject": "Account",
-      "filters": null
+      "filters": null,
+      "valueOnError": null
     },
     "filterOp": {
       "type": "SobjectRowCount",
@@ -28,6 +29,32 @@
           "value": null
         }
       ]
+    },
+    "ds": {
+      "type": "AppDatasetRowCount",
+      "dataset": "jfkdlsa",
+      "valueOnError": null
+    },
+    "orgds": {
+      "type": "OrgDatasetRowCount",
+      "dataset": "jfkdsla",
+      "valueOnError": null
+    },
+    "dc": {
+      "type": "DataCloudRowCount",
+      "object": "foo",
+      "valueOnError": null
+    },
+    "apex": {
+      "type": "ApexCallout",
+      "method": "foo",
+      "arguments": {},
+      "valueOnError": null
+    },
+    "prefs": {
+      "type": "OrgPreferenceCheck",
+      "names": ["pref1", "pref2"],
+      "valueOnError": null
     }
   }
 }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/nulls.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/readiness/valid/nulls.json
@@ -55,6 +55,11 @@
       "type": "OrgPreferenceCheck",
       "names": ["pref1", "pref2"],
       "valueOnError": null
+    },
+    "access": {
+      "type": "AccessCheck",
+      "expression": "foo",
+      "valueOnError": null
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
- adds `valueOnError` to readiness file schema for the various definition types
- adds internal `AccessCheck` definition type to readiness file schema
- now that Winter '24 should be on all pods, remove stale version availability notes in hover text on fields

### What issues does this PR fix or reference?
@W-14182424
