### PR TITLE
Templates editing updates

### DIFF
--- a/extensions/analyticsdx-vscode-templates/src/autoInstall/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/autoInstall/completions.ts
@@ -8,6 +8,7 @@
 import { Location, Node as JsonNode } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { isValidRelpath } from '../util/utils';
 import { VariableRefCompletionItemProviderDelegate } from '../variables';
 
@@ -26,11 +27,9 @@ export class AutoInstallVariableCompletionItemProviderDelegate extends VariableR
 
   public isSupportedLocation(location: Location) {
     return (
-      location.isAtPropertyKey &&
-      location.matches(['configuration', 'appConfiguration', 'values', '*']) &&
-      // this makes sure the completion only show in prop names directly under "values" (and not in prop names in object
+      // makes sure the completion only show in prop names directly under "values" (and not in prop names in object
       // values under "values")
-      location.path.length === 4
+      location.isAtPropertyKey && locationMatches(location, ['configuration', 'appConfiguration', 'values', '*'])
     );
   }
 

--- a/extensions/analyticsdx-vscode-templates/src/autoInstall/definitions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/autoInstall/definitions.ts
@@ -8,6 +8,7 @@
 import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { isValidRelpath } from '../util/utils';
 import { VariableRefDefinitionProvider } from '../variables';
 
@@ -31,7 +32,7 @@ export class AutoInstallVariableDefinitionProvider extends VariableRefDefinition
       location.previousNode?.type === 'property' &&
       location.previousNode.value &&
       // and that it's in a variable name field
-      location.matches(['configuration', 'appConfiguration', 'values', '*'])
+      locationMatches(location, ['configuration', 'appConfiguration', 'values', '*'])
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/autoInstall/hovers.ts
+++ b/extensions/analyticsdx-vscode-templates/src/autoInstall/hovers.ts
@@ -8,6 +8,7 @@
 import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { VariableRefHoverProvider } from '../variables';
 
 /** Get hover text for a variable name in the appConfiguration.values of an auto-install.json. */
@@ -24,7 +25,7 @@ export class AutoInstallVariableHoverProvider extends VariableRefHoverProvider {
     return (
       location.isAtPropertyKey &&
       location.previousNode?.type === 'property' &&
-      location.matches(['configuration', 'appConfiguration', 'values', '*'])
+      locationMatches(location, ['configuration', 'appConfiguration', 'values', '*'])
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/layout/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/layout/completions.ts
@@ -14,7 +14,12 @@ import { JsonCompletionItemProviderDelegate, newCompletionItem } from '../util/c
 import { isValidVariableName } from '../util/templateUtils';
 import { isValidRelpath } from '../util/utils';
 import { VariableRefCompletionItemProviderDelegate } from '../variables';
-import { getLayoutItemVariableName, isInTilesEnumKey, matchesLayoutItem } from './utils';
+import {
+  getLayoutItemVariableName,
+  isInComponentLayoutVariableName,
+  isInTilesEnumKey,
+  matchesLayoutItem
+} from './utils';
 
 /** Get tags from the readiness file's templateRequirements. */
 export class LayoutValidationPageTagCompletionItemProviderDelegate implements JsonCompletionItemProviderDelegate {
@@ -77,7 +82,9 @@ export class LayoutVariableCompletionItemProviderDelegate extends VariableRefCom
 
   public override isSupportedLocation(location: Location, context: vscode.CompletionContext): boolean {
     // make sure that it's in a variable name value
-    return !location.isAtPropertyKey && matchesLayoutItem(location, 'name');
+    return (
+      !location.isAtPropertyKey && (isInComponentLayoutVariableName(location) || matchesLayoutItem(location, 'name'))
+    );
   }
 }
 

--- a/extensions/analyticsdx-vscode-templates/src/layout/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/layout/completions.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import { codeCompletionUsedTelemetryCommand } from '../telemetry';
 import { TemplateDirEditing } from '../templateEditing';
 import { JsonCompletionItemProviderDelegate, newCompletionItem } from '../util/completions';
+import { locationMatches } from '../util/jsoncUtils';
 import { isValidVariableName } from '../util/templateUtils';
 import { isValidRelpath } from '../util/utils';
 import { VariableRefCompletionItemProviderDelegate } from '../variables';
@@ -39,7 +40,7 @@ export class LayoutValidationPageTagCompletionItemProviderDelegate implements Js
     // get the parent node hierarchy in the Location passed in, and it's not that big a deal if the user gets a
     // code-completion for this path in the layout.json file on a Configuration page since they'll already be getting
     // errors about the wrong type
-    return !location.isAtPropertyKey && location.matches(['pages', '*', 'groups', '*', 'tags', '*']);
+    return !location.isAtPropertyKey && locationMatches(location, ['pages', '*', 'groups', '*', 'tags', '*']);
   }
 
   public async getItems(range: vscode.Range | undefined, location: Location, document: vscode.TextDocument) {

--- a/extensions/analyticsdx-vscode-templates/src/layout/definitions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/layout/definitions.ts
@@ -14,7 +14,12 @@ import { matchJsonNodeAtPattern } from '../util/jsoncUtils';
 import { isValidRelpath } from '../util/utils';
 import { rangeForNode } from '../util/vscodeUtils';
 import { VariableRefDefinitionProvider } from '../variables';
-import { getLayoutItemVariableName, isInTilesEnumKey, matchesLayoutItem } from './utils';
+import {
+  getLayoutItemVariableName,
+  isInComponentLayoutVariableName,
+  isInTilesEnumKey,
+  matchesLayoutItem
+} from './utils';
 
 /** Handle CMD+Click from a variable name in layout.json to the variable in variables.json. */
 export class LayoutVariableDefinitionProvider extends VariableRefDefinitionProvider {
@@ -37,7 +42,7 @@ export class LayoutVariableDefinitionProvider extends VariableRefDefinitionProvi
       location.previousNode?.type === 'string' &&
       location.previousNode.value &&
       // and that it's in a variable name field
-      matchesLayoutItem(location, 'name')
+      (isInComponentLayoutVariableName(location) || matchesLayoutItem(location, 'name'))
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/layout/hovers.ts
+++ b/extensions/analyticsdx-vscode-templates/src/layout/hovers.ts
@@ -9,7 +9,7 @@ import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
 import { VariableRefHoverProvider } from '../variables';
-import { matchesLayoutItem } from './utils';
+import { isInComponentLayoutVariableName, matchesLayoutItem } from './utils';
 
 /** Get hover text for a variable from the name in a page in a layout.json file. */
 export class LayoutVariableHoverProvider extends VariableRefHoverProvider {
@@ -22,6 +22,10 @@ export class LayoutVariableHoverProvider extends VariableRefHoverProvider {
   }
 
   protected override isSupportedLocation(location: Location) {
-    return !location.isAtPropertyKey && location.previousNode?.type === 'string' && matchesLayoutItem(location, 'name');
+    return (
+      !location.isAtPropertyKey &&
+      location.previousNode?.type === 'string' &&
+      (isInComponentLayoutVariableName(location) || matchesLayoutItem(location, 'name'))
+    );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/layout/utils.ts
+++ b/extensions/analyticsdx-vscode-templates/src/layout/utils.ts
@@ -27,6 +27,11 @@ export function matchesLayoutItem(location: Location, attrName?: string) {
   return paths.some(path => location.matches(attrName ? path.concat(attrName) : (path as JSONPath)));
 }
 
+/** Tell if the specified json location is in a `Component` layout's variable's name field. */
+export function isInComponentLayoutVariableName(location: Location) {
+  return location.matches(['pages', '*', 'layout', 'variables', '*', 'name']);
+}
+
 export function isInTilesEnumKey(location: Location) {
   return (
     location.isAtPropertyKey &&

--- a/extensions/analyticsdx-vscode-templates/src/readiness/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/readiness/completions.ts
@@ -8,6 +8,7 @@
 import { Location, Node as JsonNode } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { isValidRelpath } from '../util/utils';
 import { VariableRefCompletionItemProviderDelegate } from '../variables';
 
@@ -27,10 +28,9 @@ export class ReadinessVariableCompletionItemProviderDelegate extends VariableRef
   public isSupportedLocation(location: Location) {
     return (
       location.isAtPropertyKey &&
-      location.matches(['values', '*']) &&
       // this makes sure the completion only show in prop names directly under "values" (and not in prop names in object
       // values under "values")
-      location.path.length === 2
+      locationMatches(location, ['values', '*'])
     );
   }
 

--- a/extensions/analyticsdx-vscode-templates/src/readiness/definitions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/readiness/definitions.ts
@@ -8,6 +8,7 @@
 import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { isValidRelpath } from '../util/utils';
 import { VariableRefDefinitionProvider } from '../variables';
 
@@ -31,7 +32,7 @@ export class ReadinessVariableDefinitionProvider extends VariableRefDefinitionPr
       location.previousNode?.type === 'property' &&
       location.previousNode.value &&
       // and that it's in a variable name field in values
-      location.matches(['values', '*'])
+      locationMatches(location, ['values', '*'])
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/readiness/hovers.ts
+++ b/extensions/analyticsdx-vscode-templates/src/readiness/hovers.ts
@@ -8,6 +8,7 @@
 import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { VariableRefHoverProvider } from '../variables';
 
 /** Get hover text for a variable name in the values of a readiness.json. */
@@ -21,6 +22,10 @@ export class ReadinessVariableHoverProvider extends VariableRefHoverProvider {
   }
 
   protected isSupportedLocation(location: Location) {
-    return location.isAtPropertyKey && location.previousNode?.type === 'property' && location.matches(['values', '*']);
+    return (
+      location.isAtPropertyKey &&
+      location.previousNode?.type === 'property' &&
+      locationMatches(location, ['values', '*'])
+    );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateEditing.ts
@@ -75,7 +75,7 @@ import {
 import { JsonCompletionItemProvider, newRelativeFilepathDelegate } from './util/completions';
 import { JsonAttributeRelFilePathDefinitionProvider } from './util/definitions';
 import { Disposable } from './util/disposable';
-import { matchJsonNodesAtPattern } from './util/jsoncUtils';
+import { locationMatches, matchJsonNodesAtPattern } from './util/jsoncUtils';
 import { Logger, PrefixingOutputChannel } from './util/logger';
 import { findTemplateInfoFileFor } from './util/templateUtils';
 import { isValidRelpath } from './util/utils';
@@ -276,22 +276,26 @@ export class TemplateDirEditing extends Disposable {
     const fileCompleter = new JsonCompletionItemProvider(
       // locations that support *.json fies:
       newRelativeFilepathDelegate({
-        isSupportedLocation: l => !l.isAtPropertyKey && TEMPLATE_INFO.jsonRelFilePathLocationPatterns.some(l.matches),
+        isSupportedLocation: l =>
+          !l.isAtPropertyKey && TEMPLATE_INFO.jsonRelFilePathLocationPatterns.some(p => locationMatches(l, p)),
         filter: templateJsonFileFilter
       }),
       // attributes that should have html paths
       newRelativeFilepathDelegate({
-        isSupportedLocation: l => !l.isAtPropertyKey && TEMPLATE_INFO.htmlRelFilePathLocationPatterns.some(l.matches),
+        isSupportedLocation: l =>
+          !l.isAtPropertyKey && TEMPLATE_INFO.htmlRelFilePathLocationPatterns.some(p => locationMatches(l, p)),
         filter: htmlFileFilter
       }),
       // attribute that should point to images
       newRelativeFilepathDelegate({
-        isSupportedLocation: l => !l.isAtPropertyKey && TEMPLATE_INFO.imageRelFilePathLocationPatterns.some(l.matches),
+        isSupportedLocation: l =>
+          !l.isAtPropertyKey && TEMPLATE_INFO.imageRelFilePathLocationPatterns.some(p => locationMatches(l, p)),
         filter: imageFileFilter
       }),
       // the file in externalFiles should be a .csv
       newRelativeFilepathDelegate({
-        isSupportedLocation: l => !l.isAtPropertyKey && TEMPLATE_INFO.csvRelFilePathLocationPatterns.some(l.matches),
+        isSupportedLocation: l =>
+          !l.isAtPropertyKey && TEMPLATE_INFO.csvRelFilePathLocationPatterns.some(p => locationMatches(l, p)),
         filter: csvFileFilter
       }),
       // dataModeObjects' dataset field

--- a/extensions/analyticsdx-vscode-templates/src/templateInfo/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateInfo/completions.ts
@@ -10,11 +10,12 @@ import { Location, parseTree } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { codeCompletionUsedTelemetryCommand } from '../telemetry';
 import { JsonCompletionItemProviderDelegate, newCompletionItem } from '../util/completions';
+import { locationMatches } from '../util/jsoncUtils';
 
 /** Provide completion items for a dataModelObject dataset field, from the datasetFiles' names. */
 export class DMODatasetCompletionItemProviderDelegate implements JsonCompletionItemProviderDelegate {
   public isSupportedLocation(location: Location) {
-    return !location.isAtPropertyKey && location.matches(['dataModelObjects', '*', 'dataset']);
+    return !location.isAtPropertyKey && locationMatches(location, ['dataModelObjects', '*', 'dataset']);
   }
 
   public getItems(range: vscode.Range | undefined, location: Location, document: vscode.TextDocument) {

--- a/extensions/analyticsdx-vscode-templates/src/templateInfo/definitions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/templateInfo/definitions.ts
@@ -8,6 +8,7 @@
 import { matchJsonNodesAtPattern } from '@salesforce/analyticsdx-template-lint';
 import { Location, parseTree } from 'jsonc-parser';
 import * as vscode from 'vscode';
+import { locationMatches } from '../util/jsoncUtils';
 import { rangeForNode } from '../util/vscodeUtils';
 import { JsonAttributeDefinitionProvider } from './../util/definitions';
 
@@ -28,7 +29,7 @@ export class DMODatasetDefinitionProvider extends JsonAttributeDefinitionProvide
       !location.isAtPropertyKey &&
       location.previousNode?.type === 'string' &&
       location.previousNode.value &&
-      location.matches(['dataModelObjects', '*', 'dataset'])
+      locationMatches(location, ['dataModelObjects', '*', 'dataset'])
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/ui/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/ui/completions.ts
@@ -8,6 +8,7 @@
 import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { isValidRelpath } from '../util/utils';
 import { VariableRefCompletionItemProviderDelegate } from '../variables';
 
@@ -29,7 +30,7 @@ export class UiVariableCompletionItemProviderDelegate extends VariableRefComplet
   public isSupportedLocation(location: Location, context: vscode.CompletionContext): boolean {
     return (
       // make that it's in a variable name value
-      !location.isAtPropertyKey && location.matches(['pages', '*', 'variables', '*', 'name'])
+      !location.isAtPropertyKey && locationMatches(location, ['pages', '*', 'variables', '*', 'name'])
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/ui/definitions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/ui/definitions.ts
@@ -8,6 +8,7 @@
 import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { isValidRelpath } from '../util/utils';
 import { VariableRefDefinitionProvider } from '../variables';
 
@@ -32,7 +33,7 @@ export class UiVariableDefinitionProvider extends VariableRefDefinitionProvider 
       location.previousNode?.type === 'string' &&
       location.previousNode.value &&
       // and that it's in a variable name field
-      location.matches(['pages', '*', 'variables', '*', 'name'])
+      locationMatches(location, ['pages', '*', 'variables', '*', 'name'])
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/ui/hovers.ts
+++ b/extensions/analyticsdx-vscode-templates/src/ui/hovers.ts
@@ -8,6 +8,7 @@
 import { Location } from 'jsonc-parser';
 import * as vscode from 'vscode';
 import { TemplateDirEditing } from '../templateEditing';
+import { locationMatches } from '../util/jsoncUtils';
 import { VariableRefHoverProvider } from '../variables';
 
 /** Get hover text for a variable from the name in a page in a ui.json file. */
@@ -24,7 +25,7 @@ export class UiVariableHoverProvider extends VariableRefHoverProvider {
     return (
       !location.isAtPropertyKey &&
       location.previousNode?.type === 'string' &&
-      location.matches(['pages', '*', 'variables', '*', 'name'])
+      locationMatches(location, ['pages', '*', 'variables', '*', 'name'])
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/util/definitions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/util/definitions.ts
@@ -8,6 +8,7 @@
 import { getLocation, JSONPath, Location } from 'jsonc-parser';
 import { posix as path } from 'path';
 import * as vscode from 'vscode';
+import { locationMatches } from './jsoncUtils';
 import { isValidRelpath } from './utils';
 
 /** Base class for providing definition support on fields in a json file. */
@@ -76,7 +77,7 @@ export class JsonAttributeRelFilePathDefinitionProvider extends JsonAttributeDef
       location.previousNode &&
       location.previousNode.type === 'string' &&
       location.previousNode.value &&
-      this.patterns.some(location.matches)
+      this.patterns.some(p => locationMatches(location, p))
     );
   }
 }

--- a/extensions/analyticsdx-vscode-templates/src/util/jsoncUtils.ts
+++ b/extensions/analyticsdx-vscode-templates/src/util/jsoncUtils.ts
@@ -5,13 +5,26 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { FormattingOptions, getNodePath, JSONPath, Node as JsonNode } from 'jsonc-parser';
+import { FormattingOptions, getNodePath, JSONPath, Location, Node as JsonNode } from 'jsonc-parser';
 
 export {
   jsonPathToString,
   matchJsonNodeAtPattern,
   matchJsonNodesAtPattern
 } from '@salesforce/analyticsdx-template-lint';
+
+/**
+ * Matches the location's path against a pattern consisting of strings (for properties) and numbers (for array indices).
+ * '*' will match a single segment of any property name or index.
+ * '**' will match a sequence of segments of any property name or index, or no segment.
+ * @param location the location.
+ * @param jsonpath the path pattern to match against.
+ * @param exact true (default) to exactly match the jsonpath length as well (doesn't work with '**'), or false
+ *              to check that the location starts with the jsonpath.
+ */
+export function locationMatches(location: Location, jsonpath: JSONPath, exact = true) {
+  return location.matches(jsonpath) && (!exact || location.path.length === jsonpath.length);
+}
 
 /** Find the ancestor 'property' json node at or above the specified node for the specified property.
  * This does not support wildcard paths.

--- a/extensions/analyticsdx-vscode-templates/src/variables/completions.ts
+++ b/extensions/analyticsdx-vscode-templates/src/variables/completions.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { codeCompletionUsedTelemetryCommand } from '../telemetry';
 import { TemplateDirEditing } from '../templateEditing';
 import { JsonCompletionItemProviderDelegate, newCompletionItem } from '../util/completions';
+import { locationMatches } from '../util/jsoncUtils';
 import { isValidVariableName } from '../util/templateUtils';
 
 export const NEW_VARIABLE_SNIPPETS = Object.freeze([
@@ -31,7 +32,7 @@ export class NewVariableCompletionItemProviderDelegate implements JsonCompletion
   public isSupportedLocation(location: Location) {
     return (
       // make sure it's in the empty part of the variables.json {}
-      location.isAtPropertyKey && location.matches(['*']) && location.path.length === 1
+      location.isAtPropertyKey && locationMatches(location, ['*'])
     );
   }
 

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/templateEditing/layout.test.ts
@@ -400,7 +400,7 @@ describe('TemplateEditorManager configures layoutDefinition', () => {
       const position = findPositionByJsonPath(doc, jsonpath);
       const jsonpathStr = jsonPathToString(jsonpath);
       expect(position, jsonpathStr).to.not.be.undefined;
-      let locations = await getDefinitionLocations(uri, position!.translate(undefined, 1));
+      const locations = await getDefinitionLocations(uri, position!.translate(undefined, 1));
       if (locations.length !== 1) {
         expect.fail(`${jsonpathStr}: expected 1 location, got:\n` + JSON.stringify(locations, undefined, 2));
       }

--- a/extensions/analyticsdx-vscode-templates/test/vscode-integration/utils/completions.test.ts
+++ b/extensions/analyticsdx-vscode-templates/test/vscode-integration/utils/completions.test.ts
@@ -14,6 +14,7 @@ import {
   newCompletionItem,
   newRelativeFilepathDelegate
 } from '../../../src/util/completions';
+import { locationMatches } from '../../../src/util/jsoncUtils';
 import { closeAllEditors, findPositionByJsonPath, openTemplateInfo } from '../vscodeTestUtils';
 
 const INVOKE_COMPLETION_CONTEXT: vscode.CompletionContext = {
@@ -44,7 +45,8 @@ describe('JsonCompletionItemProvider', () => {
     const provider = new JsonCompletionItemProvider(
       // locations that support *.csv fies:
       newRelativeFilepathDelegate({
-        isSupportedLocation: l => !l.isAtPropertyKey && TEMPLATE_INFO.csvRelFilePathLocationPatterns.some(l.matches),
+        isSupportedLocation: l =>
+          !l.isAtPropertyKey && TEMPLATE_INFO.csvRelFilePathLocationPatterns.some(p => locationMatches(l, p)),
         filter: csvFileFilter
       })
     );
@@ -97,7 +99,8 @@ describe('JsonCompletionItemProvider', () => {
     // make a provider with a filter that will match no files
     const provider = new JsonCompletionItemProvider(
       newRelativeFilepathDelegate({
-        isSupportedLocation: l => !l.isAtPropertyKey && TEMPLATE_INFO.csvRelFilePathLocationPatterns.some(l.matches),
+        isSupportedLocation: l =>
+          !l.isAtPropertyKey && TEMPLATE_INFO.csvRelFilePathLocationPatterns.some(p => locationMatches(l, p)),
         filter: () => false
       })
     );

--- a/packages/analyticsdx-template-lint/src/constants.ts
+++ b/packages/analyticsdx-template-lint/src/constants.ts
@@ -189,6 +189,8 @@ export const ERRORS = Object.freeze({
   LAYOUT_VALIDATION_PAGE_UNKNOWN_GROUP_TAG: 'lay-7',
   /** Multiple incldueUnmatched: true groups in a validation page. */
   LAYOUT_VALIDATION_PAGE_MULTIPLE_INCLUDE_UNMATCHED: 'lay-8',
+  /** Validate page group that has no tags and no includeUnmatched true */
+  LAYOUT_VALIDATION_PAGE_EMPTY_GROUP: 'lay-9',
 
   /** ApexCallback readiness definition but template has no apexCallback */
   READINESS_NO_APEX_CALLBACK: 'read-1',

--- a/packages/analyticsdx-template-lint/src/linter.ts
+++ b/packages/analyticsdx-template-lint/src/linter.ts
@@ -60,33 +60,30 @@ function lengthJsonArrayAttributeValue(tree: JsonNode, ...pattern: JSONPath): [n
   return [nodes ? nodes.length : -1, node];
 }
 
-/** Find all of the panel items contained in the specified layoutDefinition file's pages' layouts.
+/** Find all the names for all the variables referenced in the pages' layouts and the
+ * JsonNodes for the 'name' attribute.
  */
-function findAllItemsForLayoutDefinition(layoutJson: JsonNode): JsonNode[] {
+function findAllVariableNamesForLayoutDefinition(layoutJson: JsonNode): Array<{ name: string; nameNode: JsonNode }> {
   return matchJsonNodesAtPattern(layoutJson, ['pages', '*', 'layout']).flatMap(layout => {
     const [type] = findJsonPrimitiveAttributeValue(layout, 'type');
     if (type === 'SingleColumn') {
-      return matchJsonNodesAtPattern(layout, ['center', 'items', '*']);
+      return matchJsonNodesAtPattern(layout, ['center', 'items', '*']).flatMap(findAllVariableItemsForLayoutItem);
     } else if (type === 'TwoColumn') {
-      return matchJsonNodesAtPattern(layout, ['left', 'items', '*']).concat(
-        matchJsonNodesAtPattern(layout, ['right', 'items', '*'])
-      );
+      return matchJsonNodesAtPattern(layout, ['left', 'items', '*'])
+        .concat(matchJsonNodesAtPattern(layout, ['right', 'items', '*']))
+        .flatMap(findAllVariableItemsForLayoutItem);
+    } else if (type === 'Component') {
+      return matchJsonNodesAtPattern(
+        layout,
+        ['variables', '*', 'name'],
+        nameNode => typeof nameNode.value === 'string' && nameNode.value
+      ).map(nameNode => ({ name: nameNode.value, nameNode }));
     }
     return [];
   });
 }
 
-/** Find all the names for all the variable items in the pages' layouts and the
- * JsonNodes for the 'name' attribute.
- */
-function findAllVariableNamesForLayoutDefinition(layoutJson: JsonNode): Array<{ name: string; nameNode: JsonNode }> {
-  return findAllItemsForLayoutDefinition(layoutJson).reduce((items, item) => {
-    const variableItems = findAllVariableItemsForLayoutItem(item);
-    items.push(...variableItems);
-    return items;
-  }, [] as Array<{ name: string; nameNode: JsonNode }>);
-}
-
+/** Find the `name` node and value for all the Variable layout items at or under the passed in layout item. */
 function findAllVariableItemsForLayoutItem(item: JsonNode): Array<{ name: string; nameNode: JsonNode }> {
   const type = findJsonPrimitiveAttributeValue(item, 'type')[0];
   if (type === 'Variable') {
@@ -95,8 +92,8 @@ function findAllVariableItemsForLayoutItem(item: JsonNode): Array<{ name: string
       return [{ name, nameNode }];
     }
   } else if (type === 'GroupBox') {
-    const [nodes, node] = findJsonArrayAttributeValue(item, 'items');
-    const childrenVariableItems = nodes?.flatMap(n => findAllVariableItemsForLayoutItem(n));
+    const [nodes] = findJsonArrayAttributeValue(item, 'items');
+    const childrenVariableItems = nodes?.flatMap(findAllVariableItemsForLayoutItem);
     return childrenVariableItems ? childrenVariableItems : [];
   }
   return [];

--- a/packages/analyticsdx-template-lint/src/linter.ts
+++ b/packages/analyticsdx-template-lint/src/linter.ts
@@ -1282,6 +1282,17 @@ export abstract class TemplateLinter<
         if (includeUnmatched === true) {
           includeUnmatchedNodes.push(includeUnmatchedNode!);
         }
+
+        // each group needs at least one tag or includeUnmatched, otherwise it won't ever match anything from
+        // the validation call
+        if (tagNodes.length <= 0 && includeUnmatched !== true) {
+          this.addDiagnostic(
+            doc,
+            'No tags nor includeUnmatched true in group',
+            ERRORS.LAYOUT_VALIDATION_PAGE_EMPTY_GROUP,
+            group
+          );
+        }
       }
 
       // warn if there's more than 1 true includeUnmatched in the page

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -534,7 +534,7 @@
       ]
     },
     "visibility": {
-      "description": "Controls if this item is visible. Value must be 'Disabled' (valid only for Variable items), 'Hidden', 'Visible', or a {{...}} expression against variables that evaluates to one of those or true (Visible) or false (Hidden).",
+      "description": "Controls if this item is visible. Value must be 'Disabled' (valid only for Variable items and tiles), 'Hidden', 'Visible', or a {{...}} expression against variables that evaluates to one of those or true (Visible) or false (Hidden).",
       "oneOf": [
         {
           "type": "string",
@@ -553,12 +553,15 @@
           "type": "string",
           "default": "Visible",
           "enum": ["Disabled", "Hidden", "Visible"],
-          "enumDescriptions": ["The variable shows as disabled", "The item is hidden.", "The item is visible."]
+          "enumDescriptions": ["This item is disabled", "The item is hidden.", "The item is visible."]
         },
         {
           "type": "string",
           "$comment": "json-schema does not support case-insensitive enums, so this simulates it, using a lower-case 1st char to avoid a double schema match.",
           "pattern": "^(d[Ii][Ss][Aa][Bb][Ll][Ee][Dd]|h[Ii][Dd][Dd][Ee][Nn]|v[Ii][Ss][Ii][Bb][Ll][Ee])$"
+        },
+        {
+          "type": "null"
         }
       ]
     },
@@ -627,7 +630,8 @@
                 "type": ["string", "null"],
                 "description": "Text to display as badge in the tile. This can contain {{...}} expressions. This can contain {{...}} expressions.",
                 "defaultSnippets": [{ "label": "\"\"", "body": "${0}" }]
-              }
+              },
+              "visibility": { "$ref": "#/definitions/visibility" }
             },
             "defaultSnippets": [{ "label": "New tile", "body": { "label": "${0}" } }]
           },

--- a/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/layout-schema.json
@@ -177,6 +177,19 @@
             }
           },
           {
+            "label": "New Component page",
+            "body": {
+              "title": "${1:Page title}",
+              "type": "Configuration",
+              "layout": {
+                "type": "Component",
+                "module": "${2}",
+                "properties": {},
+                "variables": []
+              }
+            }
+          },
+          {
             "label": "New Validation page",
             "body": {
               "title": "${1:Page title}",
@@ -773,24 +786,22 @@
         "type": {
           "type": "string",
           "description": "Layout type",
-          "enum": ["SingleColumn", "TwoColumn"],
+          "enum": ["SingleColumn", "TwoColumn", "Component"],
           "enumDescriptions": [
             "A page layout with a single panel of items.",
-            "A page layout with left and right panels of items."
+            "A page layout with left and right panels of items.",
+            "A page layout using a custom Lightning Web Component for display."
           ]
         },
         "header": {
           "$ref": "#/definitions/header"
         },
-        "center": {
-          "doNotSuggest": true
-        },
-        "right": {
-          "doNotSuggest": true
-        },
-        "left": {
-          "doNotSuggest": true
-        }
+        "center": { "doNotSuggest": true },
+        "right": { "doNotSuggest": true },
+        "left": { "doNotSuggest": true },
+        "module": { "doNotSuggest": true },
+        "properties": { "doNotSuggest": true },
+        "variables": { "doNotSuggest": true }
       },
       "anyOf": [
         {
@@ -827,7 +838,56 @@
         {
           "properties": {
             "type": {
-              "not": { "enum": ["SingleColumn", "TwoColumn"] }
+              "const": "Component"
+            },
+            "module": {
+              "type": "string",
+              "description": "The component module name.",
+              "pattern": "^.+/[^/]+$",
+              "patternErrorMessage": "Must be in the format of \"namespace/componentName\".",
+              "doNotSuggest": false
+            },
+            "properties": {
+              "type": ["object", "null"],
+              "description": "Properties to set on the component. Each of these should correspond to an @api decorated property on the component. The values can include {{...}} expressions.",
+              "patternProperties": {
+                "^[^\\s]+$": {}
+              },
+              "additionalProperties": false,
+              "doNotSuggest": false,
+              "defaultSnippets": [{ "label": "{}", "body": {} }]
+            },
+            "variables": {
+              "type": ["array", "null"],
+              "description": "The variables to pass into this component. Only these variables will be available to the component, in the variables, variableValues, and variableVisibilities properties. Additionally, the variablevalueschanged event should only include updates to these variables.",
+              "items": {
+                "type": ["object"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "description": "Variable name. Must match name of variable defined in variableDefinition file.",
+                    "type": "string",
+                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+                  },
+                  "visibility": {
+                    "$ref": "#/definitions/visibility",
+                    "description": "Controls if this variable is visible. Value must be 'Disabled', 'Hidden', 'Visible', or a {{...}} expression against variables that evaluates to one of those or true (Visible) or false (Hidden). This will be sent into the variableVisibilities property on the component."
+                  }
+                },
+                "required": ["name"],
+                "defaultSnippets": [
+                  { "label": "New Variable", "body": { "name": "${1}", "visibility": "${2:Visible}" } }
+                ]
+              },
+              "doNotSuggest": false
+            }
+          },
+          "required": ["type", "module"]
+        },
+        {
+          "properties": {
+            "type": {
+              "not": { "enum": ["SingleColumn", "TwoColumn", "Component"] }
             }
           }
         }
@@ -852,6 +912,15 @@
             "right": {
               "items": []
             }
+          }
+        },
+        {
+          "label": "New Component layout",
+          "body": {
+            "type": "Component",
+            "module": "${0}",
+            "properties": {},
+            "variables": []
           }
         }
       ]

--- a/packages/analyticsdx-template-lint/src/schemas/rules-schema.json
+++ b/packages/analyticsdx-template-lint/src/schemas/rules-schema.json
@@ -106,6 +106,11 @@
                     },
                     {
                       "type": "null"
+                    },
+                    {
+                      "$comment": "This is valid, but don't show in autocomplete",
+                      "type": "string",
+                      "pattern": "^(datasetFileTemplate)$"
                     }
                   ]
                 },

--- a/packages/analyticsdx-template-lint/src/utils.ts
+++ b/packages/analyticsdx-template-lint/src/utils.ts
@@ -245,14 +245,14 @@ export function fuzzySearcher(
 /** Create a function that will cache the result of the underlying function on the first call, and
  * return that result from there out.
  */
-export function caching<A extends any[], R, T>(fn: (this: T, ...arg: A) => R): (this: T, ...arg: A) => R {
+export function caching<A extends any[], R>(fn: (...arg: A) => R): (...arg: A) => R {
   let result: R;
   let resultError: unknown | undefined;
-  let _fn: ((this: T, ...args: A) => R) | undefined = fn;
-  return function (this: T, ...args: A) {
+  let _fn: ((...args: A) => R) | undefined = fn;
+  return (...args: A) => {
     if (_fn !== undefined) {
       try {
-        result = _fn.apply(this, args);
+        result = _fn(...args);
       } catch (error) {
         resultError = error;
       }

--- a/packages/analyticsdx-template-lint/test/unit/linter/layout.test.ts
+++ b/packages/analyticsdx-template-lint/test/unit/linter/layout.test.ts
@@ -70,6 +70,15 @@ describe('TemplateLinter layout.json', () => {
                 ]
               }
             }
+          },
+          {
+            title: '',
+            type: 'Configuration',
+            layout: {
+              type: 'Component',
+              module: 'a/b',
+              variables: [{ name: 'foo' }, { name: 'bar', visibility: 'Hidden' }]
+            }
           }
         ]
       })
@@ -77,8 +86,10 @@ describe('TemplateLinter layout.json', () => {
 
     await linter.lint();
     const diagnostics = getDiagnosticsForPath(linter.diagnostics, layoutPath) || [];
-    if (diagnostics.length !== 3) {
-      expect.fail('Expected 3 unknown variable errors, got' + stringifyDiagnostics(diagnostics));
+    if (diagnostics.length !== 4) {
+      expect.fail(
+        `Expected 4 unknown variable errors, got ${diagnostics.length}: ` + stringifyDiagnostics(diagnostics)
+      );
     }
 
     let diagnostic = diagnostics.find(d => d.jsonpath === 'pages[0].layout.center.items[1].name');
@@ -93,6 +104,11 @@ describe('TemplateLinter layout.json', () => {
 
     diagnostic = diagnostics.find(d => d.jsonpath === 'pages[1].layout.left.items[0].name');
     expect(diagnostic, 'bar variable error').to.not.be.undefined;
+    expect(diagnostic!.code).to.equal(ERRORS.LAYOUT_PAGE_UNKNOWN_VARIABLE);
+    expect(diagnostic!.args).to.deep.equal({ name: 'bar', match: 'groupBar' });
+
+    diagnostic = diagnostics.find(d => d.jsonpath === 'pages[2].layout.variables[1].name');
+    expect(diagnostic, 'lwc bar variable error').to.not.be.undefined;
     expect(diagnostic!.code).to.equal(ERRORS.LAYOUT_PAGE_UNKNOWN_VARIABLE);
     expect(diagnostic!.args).to.deep.equal({ name: 'bar', match: 'groupBar' });
   });

--- a/packages/analyticsdx-template-lint/test/unit/schemas/invalidLayoutJsonTests.ts
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/invalidLayoutJsonTests.ts
@@ -27,6 +27,7 @@ describe('layout-schema.json finds errors in', () => {
       'pages[0].layout.center.items[2].items[2].visibility',
       'pages[0].layout.center.items[2].items[2].name',
       'pages[0].layout.center.items[3].variant',
+      'pages[0].layout.center.items[4].tiles.foo.visibility',
       'pages[1].layout.type',
       'pages[2].type',
       'displayMessages[0].location',

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-enums.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/invalid/invalid-enums.json
@@ -36,8 +36,18 @@
             },
             {
               "type": "Variable",
-              "name": "tiles",
+              "name": "foo",
               "variant": "badValue"
+            },
+            {
+              "type": "Variable",
+              "name": "tiles",
+              "variant": "CheckboxTiles",
+              "tiles": {
+                "foo": {
+                  "visibility": "badvalue"
+                }
+              }
             }
           ]
         }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
@@ -241,6 +241,68 @@
       }
     },
     {
+      "title": "LWC With everything",
+      "type": "Configuration",
+      "backgroundImage": {
+        "name": "name",
+        "namespace": "ns"
+      },
+      "condition": "{{true}}",
+      "helpUrl": "https://www.salesforce.com",
+      "navigation": {
+        "label": "label"
+      },
+      "guidancePanel": {
+        "title": "title",
+        "backgroundImage": {
+          "name": "name"
+        },
+        "items": [
+          {
+            "type": "Text",
+            "text": "text"
+          }
+        ]
+      },
+      "layout": {
+        "type": "Component",
+        "module": "a/b",
+        "properties": {
+          "stringProp": "Some string {{Variables.foo}}",
+          "numberProp": 42.0,
+          "booleanProp": true,
+          "nullProp": null,
+          "objectProp": {
+            "a": "b",
+            "c": -1,
+            "d": [1, false, {}]
+          },
+          "arrayProp": [1, true, [], {}]
+        },
+        "variables": [
+          {
+            "name": "someVar",
+            "visibility": "Visible"
+          },
+          {
+            "name": "someOtherVar",
+            "visibility": "{{Variables.booleanVariable ? 'Visible' : 'Disabled'}}"
+          },
+          {
+            "name": "anotherVar"
+          }
+        ]
+      }
+    },
+    {
+      "title": "Minimal LWC",
+      "type": "Configuration",
+      "layout": {
+        "type": "Component",
+        "module": "e/f"
+      }
+    },
+    {
       "title": "Validation Page",
       "type": "Validation",
       "backgroundImage": {

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/all-fields.json
@@ -50,7 +50,8 @@
                   "label": "tile label",
                   "description": "tile description",
                   "badge": "tile badge",
-                  "iconName": "utility:food_and_drink"
+                  "iconName": "utility:food_and_drink",
+                  "visibility": "Visible"
                 }
               }
             },
@@ -86,7 +87,8 @@
                       "badge": "badge",
                       "description": "description",
                       "iconName": "utilty:settings",
-                      "label": "label"
+                      "label": "label",
+                      "visibility": "{{Variables.stringVariable == 'Yes' ? 'Visible' : 'Hidden'}}"
                     }
                   }
                 },

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/nulls.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/nulls.json
@@ -42,7 +42,8 @@
                   "badge": null,
                   "description": null,
                   "iconName": null,
-                  "label": null
+                  "label": null,
+                  "visibility": null
                 }
               }
             },
@@ -63,7 +64,8 @@
                       "badge": null,
                       "description": null,
                       "iconName": null,
-                      "label": null
+                      "label": null,
+                      "visibility": null
                     }
                   }
                 }

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/nulls.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/layout/valid/nulls.json
@@ -77,6 +77,19 @@
       }
     },
     {
+      "title": "LWC",
+      "type": "Configuration",
+      "backgroundImage": null,
+      "condition": null,
+      "helpUrl": null,
+      "layout": {
+        "type": "Component",
+        "module": "foo/bar",
+        "properties": null,
+        "variables": null
+      }
+    },
+    {
       "title": "Validation page1",
       "type": "Validation",
       "backgroundImage": null,

--- a/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/rules/valid/all-fields.json
+++ b/packages/analyticsdx-template-lint/test/unit/schemas/testfiles/rules/valid/all-fields.json
@@ -90,6 +90,9 @@
         },
         {
           "type": "xmd"
+        },
+        {
+          "type": "datasetFileTemplate"
         }
       ],
       "actions": [

--- a/test-assets/sfdx-simple/force-app/main/default/waveTemplates/BadVariables/layout.json
+++ b/test-assets/sfdx-simple/force-app/main/default/waveTemplates/BadVariables/layout.json
@@ -25,6 +25,16 @@
           ]
         }
       }
+    },
+    {
+      "title": "LWC page (for testing the hover/completions/goto works",
+      "type": "Configuration",
+      "layout": {
+        "type": "Component",
+        "module": "a/b",
+        "properties": {},
+        "variables": [{ "name": "StringTypeVar" }]
+      }
     }
   ]
 }

--- a/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
+++ b/test-assets/sfdx-simple/force-app/main/default/waveTemplates/allRelpaths/layout.json
@@ -212,7 +212,8 @@
       "groups": [
         {
           "text": "group",
-          "tags": []
+          "tags": ["Tag1"],
+          "includeUnmatched": true
         }
       ]
     }


### PR DESCRIPTION
### What does this PR do?
- Add `datasetFileTemplate` to rules `appliesTo`
- Add tile `visibility` to json schema  (available in the Spring '24 release)
- Warn on empty validate page group
- Add `Component` page layout type, including completion, definition, and hover support for variables (available in the Spring '24 release)
- Remove non-arrow-function return for tslint
- Fix json path matching to be exact matching

### What issues does this PR fix or reference?
@W-14498704@, @W-14496669@, @W-14516604@, @W-14306583@