### PR TITLE
Update command expressions for switch to sf from salesforcedx-vscode-core

### DIFF
--- a/extensions/analyticsdx-vscode-core/package.json
+++ b/extensions/analyticsdx-vscode-core/package.json
@@ -135,49 +135,49 @@
         },
         {
           "command": "analyticsdx.app.create",
-          "when": "sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.app.delete",
-          "when": "sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.dashboard.lwc.create",
-          "when": "sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.studio.open",
-          "when": "sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.studio.open.app",
-          "when": "!isWeb && sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.studio.open.dataManager",
-          "when": "!isWeb && sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.template.create",
-          "when": "sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.template.delete",
-          "when": "sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.template.update",
-          "when": "sfdx:project_opened"
+          "when": "sf:project_opened"
         },
         {
           "command": "analyticsdx.template.updateFromApp",
-          "when": "sfdx:project_opened"
+          "when": "sf:project_opened"
         }
       ],
       "explorer/context": [
         {
           "command": "analyticsdx.dashboard.lwc.create",
-          "when": "explorerResourceIsFolder && resourceFilename == lwc && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == lwc && sf:project_opened"
         }
       ]
     },


### PR DESCRIPTION
### What does this PR do?
Switch the `when` clauses on our commands from `sfdx:project_opened` to `sf:project_opened`, to account for the change in forcedotcom/salesforcedx-vscode#5466.
Unfortunately, there doesn't seem to be a way to write a vscode-integration test for this -- the vscode api doesn't seem to expose access to the `when` clauses, the command palette list, or the current contexts.

### What issues does this PR fix or reference?
Fixes #173 
