### PR TITLE
Update min version of cli plugin

### DIFF
--- a/extensions/analyticsdx-vscode-core/src/util/sfdx.ts
+++ b/extensions/analyticsdx-vscode-core/src/util/sfdx.ts
@@ -31,7 +31,7 @@ const pluginName = '@salesforce/analytics';
 
 // The minumum version of the @salesforce/analytics plugins our extensions require for everything to work right,
 // and that we want folks to be at.
-const minAdxPluginVersion = '1.0.22';
+const minAdxPluginVersion = '1.4.15';
 
 export async function isSfdxInstalled(): Promise<boolean> {
   try {


### PR DESCRIPTION
### What does this PR do?
Updates the minimum version of the cli plugin to 1.4.15 to support how the vscode extensions currently execute sfdx commands with the old --loglevel arg.

### What issues does this PR fix or reference?

#175 
